### PR TITLE
change: 提前判断议题是否与发布有关

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - 跳过机器人的评论
 
+### Changed
+
+- 提前判断议题是否与发布有关
+
 ## [2.1.0] - 2023-04-08
 
 ### Added

--- a/src/plugins/publish/depends.py
+++ b/src/plugins/publish/depends.py
@@ -37,12 +37,28 @@ def get_labels(
     | IssuesEdited
     | IssueCommentCreated,
 ):
-    """获取标签"""
+    """获取议题或拉取请求的标签"""
     if isinstance(event, (PullRequestClosed, PullRequestReviewSubmitted)):
         labels = event.payload.pull_request.labels
     else:
         labels = event.payload.issue.labels
     return labels
+
+
+def get_title(
+    event: PullRequestClosed
+    | PullRequestReviewSubmitted
+    | IssuesOpened
+    | IssuesReopened
+    | IssuesEdited
+    | IssueCommentCreated,
+):
+    """获取议题或拉取请求的标题"""
+    if isinstance(event, (PullRequestClosed, PullRequestReviewSubmitted)):
+        title = event.payload.pull_request.title
+    else:
+        title = event.payload.issue.title
+    return title
 
 
 def get_type_by_labels(
@@ -52,6 +68,11 @@ def get_type_by_labels(
 ) -> PublishType | None:
     """通过标签获取类型"""
     return utils.get_type_by_labels(labels)
+
+
+def get_type_by_title(title: str = Depends(get_title)) -> PublishType | None:
+    """通过标题获取类型"""
+    return utils.get_type_by_title(title)
 
 
 async def get_pull_requests_by_label(

--- a/src/plugins/publish/depends.py
+++ b/src/plugins/publish/depends.py
@@ -45,20 +45,11 @@ def get_labels(
     return labels
 
 
-def get_title(
-    event: PullRequestClosed
-    | PullRequestReviewSubmitted
-    | IssuesOpened
-    | IssuesReopened
-    | IssuesEdited
-    | IssueCommentCreated,
+def get_issue_title(
+    event: IssuesOpened | IssuesReopened | IssuesEdited | IssueCommentCreated,
 ):
-    """获取议题或拉取请求的标题"""
-    if isinstance(event, (PullRequestClosed, PullRequestReviewSubmitted)):
-        title = event.payload.pull_request.title
-    else:
-        title = event.payload.issue.title
-    return title
+    """获取议题标题"""
+    return event.payload.issue.title
 
 
 def get_type_by_labels(
@@ -70,7 +61,7 @@ def get_type_by_labels(
     return utils.get_type_by_labels(labels)
 
 
-def get_type_by_title(title: str = Depends(get_title)) -> PublishType | None:
+def get_type_by_title(title: str = Depends(get_issue_title)) -> PublishType | None:
     """通过标题获取类型"""
     return utils.get_type_by_title(title)
 


### PR DESCRIPTION
因为就算延后执行，议题的名称也不会变。这样如果议题与发布无关就可直接跳过，少执行一次请求。