### PR TITLE
fix: 修复输出支持适配器列表未排序的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复输出支持适配器列表未排序的问题
+
 ## [2.6.1] - 2023-06-26
 
 ### Added

--- a/src/plugins/publish/validation.py
+++ b/src/plugins/publish/validation.py
@@ -286,7 +286,7 @@ class PluginPublishInfo(PublishInfo, PyPIMixin):
         return v
 
     @validator("supported_adapters", pre=True)
-    def supported_adapters_validator(cls, v: str | set[str] | None) -> set[str] | None:
+    def supported_adapters_validator(cls, v: str | set[str] | None) -> list[str] | None:
         # 如果是从 issue 中获取的数据，需要先解码
         if isinstance(v, str):
             try:
@@ -309,7 +309,7 @@ class PluginPublishInfo(PublishInfo, PyPIMixin):
             raise ValueError(
                 f"⚠️ 适配器 {', '.join(missing_adapters)} 不存在。<dt>请确保适配器模块名称正确。</dt>"
             )
-        return supported_adapters
+        return sorted(supported_adapters)
 
     @classmethod
     def get_type(cls) -> PublishType:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,7 +135,17 @@ def mocked_api(respx_mock: MockRouter):
                 "homepage": "https://onebot.adapters.nonebot.dev/",
                 "tags": [],
                 "is_official": True,
-            }
+            },
+            {
+                "module_name": "nonebot.adapters.onebot.v12",
+                "project_link": "nonebot-adapter-onebot",
+                "name": "OneBot V12",
+                "desc": "OneBot V12 协议",
+                "author": "yanyongyu",
+                "homepage": "https://onebot.adapters.nonebot.dev/",
+                "tags": [],
+                "is_official": True,
+            },
         ],
     )
     yield respx_mock

--- a/tests/publish/models/test_plugin.py
+++ b/tests/publish/models/test_plugin.py
@@ -74,7 +74,9 @@ async def test_plugin_from_issue_skip_plugin_test(
     mocker.patch.object(plugin_config, "plugin_test_result", "")
 
     mock_issue = mocker.MagicMock()
-    mock_issue.body = generate_issue_body_plugin_skip_test()
+    mock_issue.body = generate_issue_body_plugin_skip_test(
+        supported_adapters=["~onebot.v12", "nonebot.adapters.onebot.v11"]
+    )
     mock_issue.user.login = "author"
 
     info = PluginPublishInfo.from_issue(mock_issue)
@@ -89,7 +91,10 @@ async def test_plugin_from_issue_skip_plugin_test(
         tags=[{"label": "test", "color": "#ffffff"}],
         is_official=False,
         type="application",
-        supported_adapters=["nonebot.adapters.onebot.v11"],
+        supported_adapters=[
+            "nonebot.adapters.onebot.v11",
+            "nonebot.adapters.onebot.v12",
+        ],
     )
 
     assert mocked_api["project_link"].called


### PR DESCRIPTION
因为 supported_adapters 返回值为集合，所以每次输出的 json 文件排序都不一致。

切换为列表并排序来保证相同结果的一致性。