### PR TITLE
feat!: 调整商店测试输出内容

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- 商店插件列表增加插件测试时的版本号
+- 调整商店测试验证输出
+
 ## [2.7.3] - 2023-08-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ exclude_also = [
 ]
 
 [tool.coverage.run]
-omit = ["utils/plugin_test.py"]
+omit = ["src/utils/plugin_test.py"]
 
 [tool.nonebot]
 adapters = [{ name = "GitHub", module_name = "nonebot.adapters.github" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,13 @@ skip_gitignore = true
 asyncio_mode = "auto"
 
 [tool.coverage.report]
-exclude_lines = [
-  "pragma: no cover",
+exclude_also = [
   "if TYPE_CHECKING:",
   "raise NotImplementedError",
 ]
+
+[tool.coverage.run]
+omit = ["utils/plugin_test.py"]
 
 [tool.nonebot]
 adapters = [{ name = "GitHub", module_name = "nonebot.adapters.github" }]

--- a/src/plugins/publish/utils.py
+++ b/src/plugins/publish/utils.py
@@ -208,8 +208,6 @@ def validate_info_from_issue(
                 "skip_plugin_test": plugin_config.skip_plugin_test,
                 "plugin_test_result": plugin_config.plugin_test_result,
                 "plugin_test_output": plugin_config.plugin_test_output,
-                "github_repository": plugin_config.github_repository,
-                "github_run_id": plugin_config.github_run_id,
                 "previous_data": data,
             }
             # 如果插件测试被跳过，则从议题中获取信息

--- a/src/utils/store_test/constants.py
+++ b/src/utils/store_test/constants.py
@@ -3,28 +3,6 @@ from pathlib import Path
 PLUGIN_KEY_TEMPLATE = "{project_link}:{module_name}"
 """ 插件键名模板 """
 
-STORE_DIR = Path("plugin_test") / "store"
-""" 商店信息文件夹 """
-STORE_ADAPTERS_PATH = STORE_DIR / "adapters.json"
-""" 适配器列表文件路径 """
-STORE_BOTS_PATH = STORE_DIR / "bots.json"
-""" 机器人列表文件路径 """
-STORE_DRIVERS_PATH = STORE_DIR / "drivers.json"
-""" 驱动器列表文件路径 """
-STORE_PLUGINS_PATH = STORE_DIR / "plugins.json"
-""" 插件列表文件路径 """
-PREVIOUS_RESULTS_PATH = STORE_DIR / "previous_results.json"
-""" 上次测试生成的结果文件路径 """
-PREVIOUS_PLUGINS_PATH = STORE_DIR / "previous_plugins.json"
-""" 上次测试生成的插件列表文件路径 """
-MOCK_PLUGINS_PATH = STORE_DIR / "mock_plugins.json"
-""" 模拟插件列表文件路径 """
-# 通过测试的插件一定是未重复的，所以用空列表来充当插件列表文件
-if not MOCK_PLUGINS_PATH.exists():
-    MOCK_PLUGINS_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with open(MOCK_PLUGINS_PATH, "w", encoding="utf8") as f:
-        f.write("[]")
-
 TEST_DIR = Path("plugin_test")
 """ 测试文件夹 """
 if not TEST_DIR.exists():
@@ -39,3 +17,18 @@ DRIVERS_PATH = TEST_DIR / "drivers.json"
 """ 生成的驱动器列表保存路径 """
 PLUGINS_PATH = TEST_DIR / "plugins.json"
 """ 生成的插件列表保存路径 """
+
+STORE_DIR = Path("plugin_test") / "store"
+""" 商店信息文件夹 """
+STORE_ADAPTERS_PATH = STORE_DIR / "adapters.json"
+""" 适配器列表文件路径 """
+STORE_BOTS_PATH = STORE_DIR / "bots.json"
+""" 机器人列表文件路径 """
+STORE_DRIVERS_PATH = STORE_DIR / "drivers.json"
+""" 驱动器列表文件路径 """
+STORE_PLUGINS_PATH = STORE_DIR / "plugins.json"
+""" 插件列表文件路径 """
+PREVIOUS_RESULTS_PATH = STORE_DIR / "previous_results.json"
+""" 上次测试生成的结果文件路径 """
+PREVIOUS_PLUGINS_PATH = STORE_DIR / "previous_plugins.json"
+""" 上次测试生成的插件列表文件路径 """

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -53,7 +53,7 @@ class PluginValidation(TypedDict):
     """验证插件的结果与输出"""
 
     result: bool
-    output: PluginValidationOutput
+    output: PluginValidationOutput | None
     plugin: Plugin | None
 
 

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -42,11 +42,18 @@ class Metadata(TypedDict):
     supported_adapters: list[str]
 
 
+class PluginValidationOutput(TypedDict):
+    """验证插件的输出"""
+
+    data: dict[str, Any]
+    errors: list["ErrorDict"]
+
+
 class PluginValidation(TypedDict):
     """验证插件的结果与输出"""
 
     result: bool
-    output: dict[str, Any]
+    output: PluginValidationOutput
     plugin: Plugin | None
 
 

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -29,6 +29,7 @@ class Plugin(TypedDict):
     supported_adapters: list[str]
     valid: bool
     time: str
+    version: str | None
 
 
 class Metadata(TypedDict):
@@ -45,7 +46,7 @@ class PluginValidation(TypedDict):
     """验证插件的结果与输出"""
 
     result: bool
-    output: list["ErrorDict"]
+    output: dict[str, Any]
     plugin: Plugin | None
 
 

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -57,8 +57,6 @@ async def validate_plugin_info(
         raw_data["homepage"] = metadata.get("homepage")
         raw_data["type"] = metadata.get("type")
         raw_data["supported_adapters"] = metadata.get("supported_adapters")
-    else:
-        raw_data["name"] = project_link
 
     validation_result = validate_info(PublishType.PLUGIN, raw_data)
     return {

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -32,49 +32,41 @@ def extract_version(path: Path) -> str | None:
         return match.group(1).strip()
 
 
-async def validate_metadata(
+async def validate_plugin_info(
     result: bool, plugin: StorePlugin, metadata: Metadata | None
 ) -> PluginValidation:
-    """验证插件元数据"""
+    """验证插件数据"""
     project_link = plugin["project_link"]
     module_name = plugin["module_name"]
     print(f"正在验证插件 {project_link}:{module_name} ...")
 
-    if not metadata:
-        return {
-            "result": False,
-            "output": [
-                {
-                    "loc": ("metadata",),
-                    "msg": "未找到插件元数据",
-                    "type": "value_error.missing",
-                }
-            ],
-            "plugin": None,
-        }
-
-    name = metadata.get("name")
-    desc = metadata.get("description")
-    homepage = metadata.get("homepage")
-    type = metadata.get("type")
-    supported_adapters = metadata.get("supported_adapters")
-
     raw_data = {
         "module_name": module_name,
         "project_link": project_link,
-        "name": name,
-        "desc": desc,
         "author": plugin["author"],
-        "homepage": homepage,
         "tags": json.dumps(plugin["tags"]),
-        "type": type,
-        "supported_adapters": supported_adapters,
+        "skip_plugin_test": False,
+        "plugin_test_result": result,
+        "plugin_test_output": "",
         "previous_data": [],
     }
+
+    if metadata:
+        raw_data["name"] = metadata.get("name")
+        raw_data["desc"] = metadata.get("description")
+        raw_data["homepage"] = metadata.get("homepage")
+        raw_data["type"] = metadata.get("type")
+        raw_data["supported_adapters"] = metadata.get("supported_adapters")
+    else:
+        raw_data["name"] = project_link
+
     validation_result = validate_info(PublishType.PLUGIN, raw_data)
     return {
-        "result": validation_result["valid"] and result,
-        "output": validation_result["errors"] if validation_result["errors"] else [],
+        "result": validation_result["valid"],
+        "output": {
+            "data": validation_result["data"],
+            "errors": validation_result["errors"],
+        },
         "plugin": cast(Plugin, validation_result["data"])
         if validation_result["valid"]
         else None,
@@ -114,13 +106,14 @@ async def validate_plugin(
     # 测试并提取完数据后删除测试文件夹
     shutil.rmtree(test.path)
 
-    validation = await validate_metadata(load_result, plugin, metadata)
+    validation = await validate_plugin_info(load_result, plugin, metadata)
 
     new_plugin = validation["plugin"]
     if new_plugin:
         # 插件验证过程中无法获取是否是官方插件，因此需要从原始数据中获取
         new_plugin["is_official"] = is_official
         new_plugin["valid"] = validation["result"]
+        new_plugin["version"] = version
         new_plugin["time"] = now_str
 
     result: TestResult = {

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -48,6 +48,7 @@ async def validate_plugin_info(
         "skip_plugin_test": False,
         "plugin_test_result": result,
         "plugin_test_output": "",
+        "plugin_test_metadata": metadata,
         "previous_data": [],
     }
 
@@ -64,7 +65,9 @@ async def validate_plugin_info(
         "output": {
             "data": validation_result["data"],
             "errors": validation_result["errors"],
-        },
+        }
+        if not validation_result["valid"]
+        else None,
         "plugin": cast(Plugin, validation_result["data"])
         if validation_result["valid"]
         else None,

--- a/src/utils/validation/__init__.py
+++ b/src/utils/validation/__init__.py
@@ -37,7 +37,9 @@ def validate_info(
             for tag in tags
         ]
 
-    # 有些字段不需要返回
+    # 这个字段仅用于判断是否重复
+    # 如果升级至 pydantic 2 后，可以使用 validation-context
+    # https://docs.pydantic.dev/latest/usage/validators/#validation-context
     data.pop("previous_data", None)
 
     errors_with_input = []
@@ -61,6 +63,44 @@ def validate_info(
                 case _:
                     continue
             errors_with_input.append(error)
+
+    # 如果是插件，还需要额外验证插件加载测试结果
+    if publish_type == PublishType.PLUGIN:
+        skip_plugin_test = raw_data.get("skip_plugin_test")
+        plugin_test_result = raw_data.get("plugin_test_result")
+        plugin_test_output = raw_data.get("plugin_test_output")
+        plugin_test_metadata = raw_data.get("plugin_test_metadata")
+
+        if plugin_test_metadata is None and not skip_plugin_test:
+            errors_with_input.append(
+                {
+                    "loc": ("metadata",),
+                    "msg": "无法获取到插件元数据。",
+                    "type": "value_error.metadata",
+                    "ctx": {"plugin_test_result": plugin_test_result},
+                }
+            )
+            # 如果没有跳过测试且缺少插件元数据，则跳过元数据相关的错误
+            # 因为这个时候这些项都会报错，错误在此时没有意义
+            metadata_keys = ["name", "desc", "homepage", "type", "supported_adapters"]
+            errors_with_input = [
+                error
+                for error in errors_with_input
+                if error["loc"][0] not in metadata_keys
+            ]
+            # 元数据缺失时，需要删除元数据相关的字段
+            for key in metadata_keys:
+                data.pop(key, None)
+
+        if not skip_plugin_test and not plugin_test_result:
+            errors_with_input.append(
+                {
+                    "loc": ("plugin_test",),
+                    "msg": "插件无法正常加载",
+                    "type": "value_error.plugin_test",
+                    "ctx": {"output": plugin_test_output},
+                }
+            )
 
     return {
         "valid": errors is None,

--- a/tests/publish/render/test_render_error.py
+++ b/tests/publish/render/test_render_error.py
@@ -193,14 +193,10 @@ async def test_render_error_plugin(app: App, mocker: MockFixture):
     )
 
 
-async def test_render_error_plugin_load_test(app: App, mocker: MockFixture):
+async def test_render_error_plugin_load_test(app: App):
     """插件加载测试失败，并且没有获取到元数据"""
-    from src.plugins.publish.config import plugin_config
     from src.plugins.publish.render import render_comment
     from src.utils.validation import PublishType, ValidationDict
-
-    mocker.patch.object(plugin_config, "plugin_test_result", False)
-    mocker.patch.object(plugin_config, "plugin_test_output", "output")
 
     result: ValidationDict = {
         "valid": False,
@@ -212,7 +208,20 @@ async def test_render_error_plugin_load_test(app: App, mocker: MockFixture):
             "tags": [],
             "is_official": False,
         },
-        "errors": [],
+        "errors": [
+            {
+                "loc": ("metadata",),
+                "msg": "无法获取到插件元数据。",
+                "type": "value_error.metadata",
+                "ctx": {"plugin_test_result": False},
+            },
+            {
+                "loc": ("plugin_test",),
+                "msg": "插件无法正常加载",
+                "type": "value_error.plugin_test",
+                "ctx": {"output": "output"},
+            },
+        ],
         "type": PublishType.PLUGIN,
         "name": "帮助",
         "author": "he0119",
@@ -242,24 +251,10 @@ async def test_render_error_plugin_metadata(app: App, mocker: MockFixture):
         },
         "errors": [
             {
-                "loc": ("name",),
-                "msg": "field required",
-                "type": "value_error.missing",
-            },
-            {
-                "loc": ("desc",),
-                "msg": "field required",
-                "type": "value_error.missing",
-            },
-            {
-                "loc": ("homepage",),
-                "msg": "field required",
-                "type": "value_error.missing",
-            },
-            {
-                "loc": ("type",),
-                "msg": "field required",
-                "type": "value_error.missing",
+                "loc": ("metadata",),
+                "msg": "无法获取到插件元数据。",
+                "type": "value_error.metadata",
+                "ctx": {"plugin_test_result": True},
             },
         ],
         "type": PublishType.PLUGIN,

--- a/tests/utils/store_test/output.txt
+++ b/tests/utils/store_test/output.txt
@@ -1,0 +1,19 @@
+METADATA<<EOF
+{"name": "\u5e2e\u52a9", "description": "\u83b7\u53d6\u63d2\u4ef6\u5e2e\u52a9\u4fe1\u606f", "usage": "\u83b7\u53d6\u63d2\u4ef6\u5217\u8868\n/help\n\u83b7\u53d6\u63d2\u4ef6\u6811\n/help -t\n/help --tree\n\u83b7\u53d6\u67d0\u4e2a\u63d2\u4ef6\u7684\u5e2e\u52a9\n/help \u63d2\u4ef6\u540d\n\u83b7\u53d6\u67d0\u4e2a\u63d2\u4ef6\u7684\u6811\n/help --tree \u63d2\u4ef6\u540d\n", "type": "application", "homepage": "https://nonebot.dev/", "supported_adapters": null}
+EOF
+RESULT=True
+OUTPUT<<EOF
+插件 nonebot-plugin-treehelp 的信息如下：
+     name         : nonebot-plugin-treehelp 
+     version      : 0.3.0                   
+     description  : 适用于 Nonebot2 的树形帮助插件    
+    
+    dependencies
+     - nonebot2 >=2.0.0,<3.0.0
+插件 nonebot-plugin-treehelp 依赖的插件如下：
+    
+插件 nonebot_plugin_treehelp 加载正常：
+    08-23 09:00:03 [SUCCESS] nonebot | NoneBot is initializing...
+    08-23 09:00:03 [INFO] nonebot | Current Env: prod
+    08-23 09:00:03 [SUCCESS] nonebot | Succeeded to load plugin "nonebot_plugin_treehelp"
+EOF

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -1,0 +1,69 @@
+import shutil
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+from pytest_mock import MockerFixture
+from respx import MockRouter
+
+
+async def test_validate_plugin(
+    tmp_path: Path, mocked_api: MockRouter, mocker: MockerFixture
+) -> None:
+    """验证插件信息"""
+    from src.utils.store_test.validation import StorePlugin, validate_plugin
+
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
+
+    plugin_test_dir = tmp_path / "plugin_test"
+    plugin_test_dir.mkdir()
+
+    output_path = Path(__file__).parent / "output.txt"
+    temp_output_path = plugin_test_dir / "output.txt"
+    shutil.copyfile(output_path, temp_output_path)
+
+    assert temp_output_path.exists()
+
+    mock_plugin_test = mocker.MagicMock()
+    mocker.patch(
+        "src.utils.store_test.validation.PluginTest", return_value=mock_plugin_test
+    )
+    mock_run = mocker.AsyncMock()
+    mock_run.return_value = (True, "output")
+    mock_plugin_test.run = mock_run
+    mock_plugin_test.path = plugin_test_dir
+
+    plugin = StorePlugin(
+        module_name="module_name",
+        project_link="project_link",
+        author="author",
+        tags=[],
+        is_official=False,
+    )
+
+    result, new_plugin = await validate_plugin(plugin, "")
+
+    assert result["version"] == "0.3.0"
+    assert new_plugin == {
+        "author": "author",
+        "desc": "获取插件帮助信息",
+        "homepage": "https://nonebot.dev/",
+        "is_official": False,
+        "module_name": "module_name",
+        "name": "帮助",
+        "project_link": "project_link",
+        "supported_adapters": None,
+        "tags": [],
+        "time": "2023-08-23T09:22:14.836035+08:00",
+        "type": "application",
+        "valid": True,
+        "version": "0.3.0",
+    }
+
+    assert mocked_api["homepage"].called
+
+    assert not temp_output_path.exists()
+    assert not plugin_test_dir.exists()

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -46,7 +46,28 @@ async def test_validate_plugin(
 
     result, new_plugin = await validate_plugin(plugin, "")
 
-    assert result["version"] == "0.3.0"
+    assert result == {
+        "time": "2023-08-23T09:22:14.836035+08:00",
+        "version": "0.3.0",
+        "inputs": {"config": ""},
+        "results": {
+            "load": True,
+            "metadata": True,
+            "validation": True,
+        },
+        "outputs": {
+            "load": "output",
+            "metadata": {
+                "name": "帮助",
+                "description": "获取插件帮助信息",
+                "usage": "获取插件列表\n/help\n获取插件树\n/help -t\n/help --tree\n获取某个插件的帮助\n/help 插件名\n获取某个插件的树\n/help --tree 插件名\n",
+                "type": "application",
+                "homepage": "https://nonebot.dev/",
+                "supported_adapters": None,
+            },
+            "validation": None,
+        },
+    }
     assert new_plugin == {
         "author": "author",
         "desc": "获取插件帮助信息",

--- a/tests/utils/store_test/test_validate_plugin_info.py
+++ b/tests/utils/store_test/test_validate_plugin_info.py
@@ -1,0 +1,24 @@
+from respx import MockRouter
+
+
+async def test_validate_plugin_info(mocked_api: MockRouter) -> None:
+    """验证插件信息"""
+    from src.utils.store_test.validation import StorePlugin, validate_plugin_info
+
+    plugin = StorePlugin(
+        module_name="module_name",
+        project_link="project_link",
+        author="author",
+        tags=[],
+        is_official=False,
+    )
+
+    result = await validate_plugin_info(False, plugin, None)
+
+    assert not result["result"]
+    assert "name" not in result["output"]["data"]
+    assert result["output"]["errors"]
+    assert result["output"]["errors"][0]["loc"] == ("metadata",)
+    assert result["output"]["errors"][0]["type"] == "value_error.metadata"
+
+    assert not mocked_api["homepage"].called

--- a/tests/utils/store_test/test_validate_plugin_info.py
+++ b/tests/utils/store_test/test_validate_plugin_info.py
@@ -16,6 +16,7 @@ async def test_validate_plugin_info(mocked_api: MockRouter) -> None:
     result = await validate_plugin_info(False, plugin, None)
 
     assert not result["result"]
+    assert result["output"]
     assert "name" not in result["output"]["data"]
     assert result["output"]["errors"]
     assert result["output"]["errors"][0]["loc"] == ("metadata",)

--- a/tests/utils/validation/utils.py
+++ b/tests/utils/validation/utils.py
@@ -81,8 +81,7 @@ def generate_plugin_data(
             "skip_plugin_test": skip_plugin_test,
             "plugin_test_result": plugin_test_result,
             "plugin_test_output": plugin_test_output,
+            "plugin_test_metadata": {},
             "previous_data": previous_data,
-            "github_repository": "github",
-            "github_run_id": "123456",
         }
     )


### PR DESCRIPTION
validation.output 会直接返回验证通过的数据与错误。如果所有数据均验证通过，则返回 None。

同时将插件加载测试相关验证移至 validate_info 函数内，这样商店测试那边也能获得完整的验证信息。

插件信息增加测试时插件的版本号。