### PR TITLE
fix(store_test): 跳过测试的插件需要从之前的数据中提取验证所需数据

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修正字段名称为 skip_test
+- 跳过测试的插件需要从之前的数据中提取验证所需数据
 
 ## [3.0.1] - 2023-08-28
 

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -30,7 +30,7 @@ class Plugin(TypedDict):
     valid: bool
     time: str
     version: str | None
-    skip_plugin_test: bool
+    skip_test: bool
 
 
 class Metadata(TypedDict):

--- a/src/utils/store_test/store.py
+++ b/src/utils/store_test/store.py
@@ -103,10 +103,11 @@ class StoreTest:
 
             print(f"正在测试插件 {key} ...")
             new_results[key], new_plugin = await validate_plugin(
-                self._store_plugins[key],
-                config or "",
-                self.skip_plugin_test(key),
-                data,
+                plugin=self._store_plugins[key],
+                config=config or "",
+                skip_test=self.skip_plugin_test(key),
+                data=data,
+                previous_plugin=self._previous_plugins.get(key),
             )
             if new_plugin:
                 new_plugins[key] = new_plugin
@@ -133,9 +134,10 @@ class StoreTest:
                 print(f"{i}/{self._limit} 正在测试插件 {key} ...")
 
                 new_results[key], new_plugin = await validate_plugin(
-                    plugin,
-                    plugin_configs.get(key, ""),
-                    self.skip_plugin_test(key),
+                    plugin=plugin,
+                    config=plugin_configs.get(key, ""),
+                    skip_test=self.skip_plugin_test(key),
+                    previous_plugin=self._previous_plugins.get(key),
                 )
                 if new_plugin:
                     new_plugins[key] = new_plugin

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -33,7 +33,11 @@ def extract_version(path: Path) -> str | None:
 
 
 async def validate_plugin(
-    plugin: StorePlugin, config: str, skip_test: bool, data: str | None = None
+    plugin: StorePlugin,
+    config: str,
+    skip_test: bool,
+    data: str | None = None,
+    previous_plugin: Plugin | None = None,
 ) -> tuple[TestResult, Plugin | None]:
     """验证插件
 
@@ -115,6 +119,12 @@ async def validate_plugin(
             raw_data["homepage"] = metadata.get("homepage")
             raw_data["type"] = metadata.get("type")
             raw_data["supported_adapters"] = metadata.get("supported_adapters")
+        elif skip_test and previous_plugin:
+            raw_data["name"] = previous_plugin.get("name")
+            raw_data["desc"] = previous_plugin.get("desc")
+            raw_data["homepage"] = previous_plugin.get("homepage")
+            raw_data["type"] = previous_plugin.get("type")
+            raw_data["supported_adapters"] = previous_plugin.get("supported_adapters")
 
         validation_info_result = validate_info(PublishType.PLUGIN, raw_data)
 

--- a/tests/utils/store_test/output_failed.txt
+++ b/tests/utils/store_test/output_failed.txt
@@ -1,0 +1,16 @@
+RESULT=False
+OUTPUT<<EOF
+插件 nonebot-plugin-treehelp 的信息如下：
+     name         : nonebot-plugin-treehelp 
+     version      : 0.3.0                   
+     description  : 适用于 Nonebot2 的树形帮助插件    
+    
+    dependencies
+     - nonebot2 >=2.0.0,<3.0.0
+插件 nonebot-plugin-treehelp 依赖的插件如下：
+    
+插件 nonebot_plugin_treehelp 加载正常：
+    08-23 09:00:03 [SUCCESS] nonebot | NoneBot is initializing...
+    08-23 09:00:03 [INFO] nonebot | Current Env: prod
+    08-23 09:00:03 [SUCCESS] nonebot | Succeeded to load plugin "nonebot_plugin_treehelp"
+EOF

--- a/tests/utils/store_test/test_store_test.py
+++ b/tests/utils/store_test/test_store_test.py
@@ -126,15 +126,29 @@ async def test_store_test(
     await test.run()
 
     mocked_validate_plugin.assert_called_once_with(
-        {
+        plugin={
             "module_name": "nonebot_plugin_treehelp",
             "project_link": "nonebot-plugin-treehelp",
             "author": "he0119",
             "tags": [],
             "is_official": False,
         },
-        "",
-        False,
+        config="",
+        skip_test=False,
+        previous_plugin={
+            "module_name": "nonebot_plugin_treehelp",
+            "project_link": "nonebot-plugin-treehelp",
+            "name": "帮助",
+            "desc": "获取插件帮助信息",
+            "author": "he0119",
+            "homepage": "https://github.com/he0119/nonebot-plugin-treehelp",
+            "tags": [],
+            "is_official": False,
+            "type": "application",
+            "supported_adapters": None,
+            "valid": True,
+            "time": "2023-06-22 12:10:18",
+        },
     )
     assert mocked_api["project_link_treehelp"].called
     assert mocked_api["project_link_datastore"].called
@@ -174,16 +188,30 @@ async def test_store_test_with_key(
     await test.run(key="nonebot-plugin-treehelp:nonebot_plugin_treehelp")
 
     mocked_validate_plugin.assert_called_once_with(
-        {
+        plugin={
             "module_name": "nonebot_plugin_treehelp",
             "project_link": "nonebot-plugin-treehelp",
             "author": "he0119",
             "tags": [],
             "is_official": False,
         },
-        "",
-        False,
-        None,
+        config="",
+        skip_test=False,
+        data=None,
+        previous_plugin={
+            "module_name": "nonebot_plugin_treehelp",
+            "project_link": "nonebot-plugin-treehelp",
+            "name": "帮助",
+            "desc": "获取插件帮助信息",
+            "author": "he0119",
+            "homepage": "https://github.com/he0119/nonebot-plugin-treehelp",
+            "tags": [],
+            "is_official": False,
+            "type": "application",
+            "supported_adapters": None,
+            "valid": True,
+            "time": "2023-06-22 12:10:18",
+        },
     )
     assert mocked_api["project_link_treehelp"].called
     assert not mocked_api["project_link_datastore"].called
@@ -218,16 +246,17 @@ async def test_store_test_with_key_not_in_previous(
     await test.run(key="nonebot-plugin-wordcloud:nonebot_plugin_wordcloud")
 
     mocked_validate_plugin.assert_called_once_with(
-        {
+        plugin={
             "module_name": "nonebot_plugin_wordcloud",
             "project_link": "nonebot-plugin-wordcloud",
             "author": "he0119",
             "tags": [],
             "is_official": False,
         },
-        "",
-        False,
-        None,
+        config="",
+        skip_test=False,
+        data=None,
+        previous_plugin=None,
     )
 
     # 不需要判断版本号

--- a/tests/utils/store_test/test_store_test.py
+++ b/tests/utils/store_test/test_store_test.py
@@ -118,7 +118,7 @@ async def test_store_test(
             time="2023-08-28T00:00:00.000000+08:00",
             is_official=True,
             valid=True,
-            skip_plugin_test=False,
+            skip_test=False,
         ),
     )
 
@@ -171,7 +171,7 @@ async def test_store_test(
     )
     assert (
         mocked_store_data["plugins"].read_text(encoding="utf8")
-        == '[{"module_name":"nonebot_plugin_datastore","project_link":"nonebot-plugin-datastore","name":"数据存储","desc":"NoneBot 数据存储插件","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-datastore","tags":[],"is_official":false,"type":"library","supported_adapters":null,"valid":true,"time":"2023-06-22 11:58:18"},{"name":"帮助","module_name":"module_name","author":"author","version":"0.3.0","desc":"获取插件帮助信息","homepage":"https://nonebot.dev/","project_link":"project_link","tags":[],"supported_adapters":null,"type":"application","time":"2023-08-28T00:00:00.000000+08:00","is_official":true,"valid":true,"skip_plugin_test":false}]'
+        == '[{"module_name":"nonebot_plugin_datastore","project_link":"nonebot-plugin-datastore","name":"数据存储","desc":"NoneBot 数据存储插件","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-datastore","tags":[],"is_official":false,"type":"library","supported_adapters":null,"valid":true,"time":"2023-06-22 11:58:18"},{"name":"帮助","module_name":"module_name","author":"author","version":"0.3.0","desc":"获取插件帮助信息","homepage":"https://nonebot.dev/","project_link":"project_link","tags":[],"supported_adapters":null,"type":"application","time":"2023-08-28T00:00:00.000000+08:00","is_official":true,"valid":true,"skip_test":false}]'
     )
 
 

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -278,7 +278,7 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
 
-    output_path = Path(__file__).parent / "output.txt"
+    output_path = Path(__file__).parent / "output_failed.txt"
     temp_output_path = plugin_test_dir / "output.txt"
     shutil.copyfile(output_path, temp_output_path)
 
@@ -301,7 +301,27 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
         is_official=False,
     )
 
-    result, new_plugin = await validate_plugin(plugin, "", True)
+    result, new_plugin = await validate_plugin(
+        plugin,
+        "",
+        True,
+        previous_plugin={
+            "module_name": "nonebot_plugin_treehelp",
+            "project_link": "nonebot-plugin-treehelp",
+            "name": "帮助",
+            "desc": "获取插件帮助信息",
+            "author": "he0119",
+            "homepage": "https://nonebot.dev/",
+            "tags": [],
+            "is_official": False,
+            "type": "application",
+            "supported_adapters": None,
+            "valid": True,
+            "time": "2023-06-22 12:10:18",
+            "version": "0.3.0",
+            "skip_test": True,
+        },
+    )
 
     assert result == {
         "time": "2023-08-23T09:22:14.836035+08:00",
@@ -309,19 +329,12 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
         "inputs": {"config": ""},
         "results": {
             "load": False,
-            "metadata": True,
+            "metadata": False,
             "validation": True,
         },
         "outputs": {
             "load": "output",
-            "metadata": {
-                "name": "帮助",
-                "description": "获取插件帮助信息",
-                "usage": "获取插件列表\n/help\n获取插件树\n/help -t\n/help --tree\n获取某个插件的帮助\n/help 插件名\n获取某个插件的树\n/help --tree 插件名\n",
-                "type": "application",
-                "homepage": "https://nonebot.dev/",
-                "supported_adapters": None,
-            },
+            "metadata": None,
             "validation": None,
         },
     }

--- a/tests/utils/validation/utils.py
+++ b/tests/utils/validation/utils.py
@@ -60,7 +60,7 @@ def generate_plugin_data(
     homepage: str | None = "https://nonebot.dev",
     type: str | None = "application",
     supported_adapters: list[str] | None = None,
-    skip_plugin_test: bool | None = False,
+    skip_test: bool | None = False,
     plugin_test_result: bool | None = True,
     plugin_test_output: str | None = "plugin_test_output",
     previous_data: list[Any] | None = [],
@@ -78,7 +78,7 @@ def generate_plugin_data(
             "supported_adapters": json.dumps(supported_adapters)
             if supported_adapters is not None
             else None,
-            "skip_plugin_test": skip_plugin_test,
+            "skip_test": skip_test,
             "plugin_test_result": plugin_test_result,
             "plugin_test_output": plugin_test_output,
             "plugin_test_metadata": {},


### PR DESCRIPTION
因为其插件加载测试无法通过，也就没法获取所需的 metadata。