### PR TITLE
feat: 用 PyPI 项目的文件上传时间替换测试时间

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- 用 PyPI 项目的文件上传时间替换测试时间
+
 ## [3.0.3] - 2023-08-30
 
 ### Added

--- a/src/utils/store_test/store.py
+++ b/src/utils/store_test/store.py
@@ -1,5 +1,3 @@
-import httpx
-
 from .constants import (
     ADAPTERS_PATH,
     BOTS_PATH,
@@ -15,7 +13,7 @@ from .constants import (
     STORE_PLUGINS_PATH,
 )
 from .models import Plugin, StorePlugin, TestResult
-from .utils import dump_json, load_json
+from .utils import dump_json, get_latest_version, load_json
 from .validation import validate_plugin
 
 
@@ -53,18 +51,6 @@ class StoreTest:
             for plugin in load_json(PREVIOUS_PLUGINS_PATH)
         }
 
-    @staticmethod
-    def get_latest_version(project_link: str) -> str | None:
-        headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
-        }
-        url = f"https://pypi.org/pypi/{project_link}/json"
-        r = httpx.get(url, headers=headers)
-        if r.status_code == 200:
-            return r.json()["info"]["version"]
-        else:
-            return None
-
     def should_skip(self, key: str) -> bool:
         """是否跳过测试"""
         # 如果强制测试，则不跳过
@@ -78,7 +64,7 @@ class StoreTest:
             return False
 
         # 如果插件为最新版本，则跳过测试
-        latest_version = self.get_latest_version(previous_plugin["project_link"])
+        latest_version = get_latest_version(previous_plugin["project_link"])
         if latest_version == previous_result["version"]:
             print(f"插件 {key} 为最新版本（{latest_version}），跳过测试")
             return True

--- a/src/utils/store_test/utils.py
+++ b/src/utils/store_test/utils.py
@@ -1,9 +1,7 @@
 import json
-from datetime import datetime
 from functools import cache
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import httpx
 
@@ -44,9 +42,8 @@ def get_latest_version(project_link: str) -> str | None:
         return data["info"]["version"]
 
 
-def get_upload_time(project_link: str) -> str:
+def get_upload_time(project_link: str) -> str | None:
     """获取插件的上传时间"""
     if data := get_pypi_data(project_link):
         if len(data["urls"]) != 0:
             return data["urls"][0]["upload_time_iso_8601"]
-    return datetime.now(ZoneInfo("Asia/Shanghai")).isoformat()

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -48,6 +48,8 @@ async def validate_plugin(
 
     如果插件验证失败，返回的插件数据为 None
     """
+    # 当前时间
+    now_time_str = datetime.now(ZoneInfo("Asia/Shanghai")).isoformat()
     # 需要从商店插件数据中获取的信息
     project_link = plugin["project_link"]
     module_name = plugin["module_name"]
@@ -70,7 +72,7 @@ async def validate_plugin(
         new_plugin = json.loads(data)
         new_plugin["valid"] = True
         new_plugin["version"] = version
-        new_plugin["time"] = upload_time_str
+        new_plugin["time"] = upload_time_str or now_time_str
         new_plugin["skip_test"] = True
         new_plugin = cast(Plugin, new_plugin)
 
@@ -135,7 +137,7 @@ async def validate_plugin(
             new_plugin["is_official"] = is_official
             new_plugin["valid"] = validation_info_result["valid"]
             new_plugin["version"] = version
-            new_plugin["time"] = upload_time_str
+            new_plugin["time"] = upload_time_str or now_time_str
             new_plugin["skip_test"] = should_skip
             new_plugin = cast(Plugin, new_plugin)
         else:
@@ -152,7 +154,7 @@ async def validate_plugin(
         )
 
     result: TestResult = {
-        "time": datetime.now(ZoneInfo("Asia/Shanghai")).isoformat(),
+        "time": now_time_str,
         "version": version,
         "results": {
             "validation": validation_result,

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -12,6 +12,7 @@ from src.utils.plugin_test import PluginTest, strip_ansi
 from src.utils.validation import PublishType, validate_info
 
 from .models import Metadata, Plugin, StorePlugin, TestResult
+from .utils import get_upload_time
 
 
 def extract_metadata(path: Path) -> Metadata | None:
@@ -47,12 +48,12 @@ async def validate_plugin(
 
     如果插件验证失败，返回的插件数据为 None
     """
-    now_str = datetime.now(ZoneInfo("Asia/Shanghai")).isoformat()
     # 需要从商店插件数据中获取的信息
     project_link = plugin["project_link"]
     module_name = plugin["module_name"]
     is_official = plugin["is_official"]
-
+    # 获取插件上传时间
+    upload_time_str = get_upload_time(project_link)
     # 如果传递了 data 参数
     # 则直接使用 data 作为插件数据
     # 并且将 skip_test 设置为 True
@@ -69,7 +70,7 @@ async def validate_plugin(
         new_plugin = json.loads(data)
         new_plugin["valid"] = True
         new_plugin["version"] = version
-        new_plugin["time"] = now_str
+        new_plugin["time"] = upload_time_str
         new_plugin["skip_test"] = True
         new_plugin = cast(Plugin, new_plugin)
 
@@ -134,7 +135,7 @@ async def validate_plugin(
             new_plugin["is_official"] = is_official
             new_plugin["valid"] = validation_info_result["valid"]
             new_plugin["version"] = version
-            new_plugin["time"] = now_str
+            new_plugin["time"] = upload_time_str
             new_plugin["skip_test"] = should_skip
             new_plugin = cast(Plugin, new_plugin)
         else:
@@ -151,7 +152,7 @@ async def validate_plugin(
         )
 
     result: TestResult = {
-        "time": now_str,
+        "time": datetime.now(ZoneInfo("Asia/Shanghai")).isoformat(),
         "version": version,
         "results": {
             "validation": validation_result,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,11 @@ async def app(app: App, tmp_path: Path, mocker: MockerFixture):
     mocker.patch.object(plugin_config.input_config, "plugin_path", plugin_path)
     mocker.patch.object(plugin_config, "skip_plugin_test", False)
 
-    return app
+    yield app
+
+    from src.utils.store_test.utils import get_pypi_data
+
+    get_pypi_data.cache_clear()
 
 
 @pytest.fixture(autouse=True, scope="function")
@@ -115,7 +119,18 @@ def mocked_api(respx_mock: MockRouter):
     respx_mock.get("exception", name="exception").mock(side_effect=httpx.ConnectError)
     respx_mock.get(
         "https://pypi.org/pypi/project_link/json", name="project_link"
-    ).respond()
+    ).respond(
+        json={
+            "info": {
+                "version": "0.0.1",
+            },
+            "urls": [
+                {
+                    "upload_time_iso_8601": "2023-09-01T00:00:00+00:00Z",
+                }
+            ],
+        }
+    )
     respx_mock.get(
         "https://pypi.org/pypi/nonebot-plugin-treehelp/json",
         name="project_link_treehelp",
@@ -123,7 +138,12 @@ def mocked_api(respx_mock: MockRouter):
         json={
             "info": {
                 "version": "0.3.1",
-            }
+            },
+            "urls": [
+                {
+                    "upload_time_iso_8601": "2021-08-01T00:00:00+00:00",
+                }
+            ],
         }
     )
     respx_mock.get(

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -1,6 +1,8 @@
 import json
 import shutil
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from pytest_mock import MockerFixture
 from respx import MockRouter
@@ -11,6 +13,11 @@ async def test_validate_plugin(
 ) -> None:
     """验证插件信息"""
     from src.utils.store_test.validation import StorePlugin, validate_plugin
+
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
 
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
@@ -41,7 +48,7 @@ async def test_validate_plugin(
     result, new_plugin = await validate_plugin(plugin, "", False)
 
     assert result == {
-        "time": "2023-09-01T00:00:00+00:00Z",
+        "time": "2023-08-23T09:22:14.836035+08:00",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -94,6 +101,11 @@ async def test_validate_plugin_with_data(
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
 
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
+
     mocked_plugin_test = mocker.patch("src.utils.store_test.validation.PluginTest")
 
     plugin = StorePlugin(
@@ -120,7 +132,7 @@ async def test_validate_plugin_with_data(
     result, new_plugin = await validate_plugin(plugin, "", False, json.dumps(data))
 
     assert result == {
-        "time": "2023-09-01T00:00:00+00:00Z",
+        "time": "2023-08-23T09:22:14.836035+08:00",
         "version": None,
         "inputs": {"config": ""},
         "results": {
@@ -171,6 +183,11 @@ async def test_validate_plugin_skip_test(
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
 
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
+
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
 
@@ -200,7 +217,7 @@ async def test_validate_plugin_skip_test(
     result, new_plugin = await validate_plugin(plugin, "", True)
 
     assert result == {
-        "time": "2023-09-01T00:00:00+00:00Z",
+        "time": "2023-08-23T09:22:14.836035+08:00",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -253,6 +270,11 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
 
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
+
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
 
@@ -302,7 +324,7 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
     )
 
     assert result == {
-        "time": "2023-09-01T00:00:00+00:00Z",
+        "time": "2023-08-23T09:22:14.836035+08:00",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -345,6 +367,11 @@ async def test_validate_plugin_failed(
     """插件验证失败的情况"""
     from src.utils.store_test.validation import StorePlugin, validate_plugin
 
+    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
+    mock_datetime.now.return_value = datetime(
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+    )
+
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
 
@@ -374,7 +401,7 @@ async def test_validate_plugin_failed(
     result, new_plugin = await validate_plugin(plugin, "", False)
 
     assert result == {
-        "time": "2023-09-01T00:00:00+00:00Z",
+        "time": "2023-08-23T09:22:14.836035+08:00",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -1,8 +1,6 @@
 import json
 import shutil
-from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from pytest_mock import MockerFixture
 from respx import MockRouter
@@ -13,11 +11,6 @@ async def test_validate_plugin(
 ) -> None:
     """验证插件信息"""
     from src.utils.store_test.validation import StorePlugin, validate_plugin
-
-    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
-    mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
-    )
 
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
@@ -48,7 +41,7 @@ async def test_validate_plugin(
     result, new_plugin = await validate_plugin(plugin, "", False)
 
     assert result == {
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -79,7 +72,7 @@ async def test_validate_plugin(
         "project_link": "project_link",
         "supported_adapters": None,
         "tags": [],
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "type": "application",
         "valid": True,
         "version": "0.3.0",
@@ -100,11 +93,6 @@ async def test_validate_plugin_with_data(
     应该不会调用 API，直接使用传递进来的数据，并且 metadata 会缺少 usage（因为拉取请求关闭时无法获取，所以并没有传递过来）。
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
-
-    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
-    mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
-    )
 
     mocked_plugin_test = mocker.patch("src.utils.store_test.validation.PluginTest")
 
@@ -132,7 +120,7 @@ async def test_validate_plugin_with_data(
     result, new_plugin = await validate_plugin(plugin, "", False, json.dumps(data))
 
     assert result == {
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "version": None,
         "inputs": {"config": ""},
         "results": {
@@ -163,7 +151,7 @@ async def test_validate_plugin_with_data(
         "is_official": False,
         "supported_adapters": None,
         "type": "application",
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "valid": True,
         "version": None,
         "skip_test": True,
@@ -182,11 +170,6 @@ async def test_validate_plugin_skip_test(
     如果插件之前是跳过测试的，如果插件测试成功，应将 skip_test 设置为 False。
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
-
-    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
-    mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
-    )
 
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
@@ -217,7 +200,7 @@ async def test_validate_plugin_skip_test(
     result, new_plugin = await validate_plugin(plugin, "", True)
 
     assert result == {
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -248,7 +231,7 @@ async def test_validate_plugin_skip_test(
         "project_link": "project_link",
         "supported_adapters": None,
         "tags": [],
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "type": "application",
         "valid": True,
         "version": "0.3.0",
@@ -269,11 +252,6 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
     如果插件之前是跳过测试的，如果插件测试失败，应不改变 skip_test 的值。
     """
     from src.utils.store_test.validation import StorePlugin, validate_plugin
-
-    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
-    mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
-    )
 
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
@@ -324,7 +302,7 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
     )
 
     assert result == {
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {
@@ -348,7 +326,7 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
         "project_link": "project_link",
         "supported_adapters": None,
         "tags": [],
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "type": "application",
         "valid": True,
         "version": "0.3.0",
@@ -366,11 +344,6 @@ async def test_validate_plugin_failed(
 ) -> None:
     """插件验证失败的情况"""
     from src.utils.store_test.validation import StorePlugin, validate_plugin
-
-    mock_datetime = mocker.patch("src.utils.store_test.validation.datetime")
-    mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
-    )
 
     plugin_test_dir = tmp_path / "plugin_test"
     plugin_test_dir.mkdir()
@@ -401,7 +374,7 @@ async def test_validate_plugin_failed(
     result, new_plugin = await validate_plugin(plugin, "", False)
 
     assert result == {
-        "time": "2023-08-23T09:22:14.836035+08:00",
+        "time": "2023-09-01T00:00:00+00:00Z",
         "version": "0.3.0",
         "inputs": {"config": ""},
         "results": {


### PR DESCRIPTION
plugins.json 中的 time 字段调整为文件上传时间。results.json 中的 time 不变，为测试时间。

close #179