### PR TITLE
fix: 修复跳过插件测试时无法获取插件版本与时间的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ### Fixed
 
-- 修复传入数据时无法获取插件版本与时间的问题
+- 修复跳过插件测试时无法获取插件版本与时间的问题
 
 ## [3.0.4] - 2023-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复传入数据时无法获取插件版本与时间的问题
+
 ## [3.0.4] - 2023-09-06
 
 ### Changed

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -25,8 +25,8 @@ class Plugin(TypedDict):
     type: str
     supported_adapters: list[str] | None
     valid: bool
-    time: str | None
-    version: str | None
+    time: str
+    version: str
     skip_test: bool
 
 

--- a/src/utils/store_test/models.py
+++ b/src/utils/store_test/models.py
@@ -25,7 +25,7 @@ class Plugin(TypedDict):
     type: str
     supported_adapters: list[str] | None
     valid: bool
-    time: str
+    time: str | None
     version: str | None
     skip_test: bool
 

--- a/src/utils/store_test/utils.py
+++ b/src/utils/store_test/utils.py
@@ -25,7 +25,7 @@ def dump_json(path: Path, data: dict | list):
 
 
 @cache
-def get_pypi_data(project_link: str) -> dict[str, Any] | None:
+def get_pypi_data(project_link: str) -> dict[str, Any]:
     """获取 PyPI 数据"""
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36"
@@ -34,16 +34,16 @@ def get_pypi_data(project_link: str) -> dict[str, Any] | None:
     r = httpx.get(url, headers=headers)
     if r.status_code == 200:
         return r.json()
+    raise ValueError(f"获取 PyPI 数据失败：{r.text}")
 
 
-def get_latest_version(project_link: str) -> str | None:
+def get_latest_version(project_link: str) -> str:
     """获取插件的最新版本号"""
-    if data := get_pypi_data(project_link):
-        return data["info"]["version"]
+    data = get_pypi_data(project_link)
+    return data["info"]["version"]
 
 
-def get_upload_time(project_link: str) -> str | None:
+def get_upload_time(project_link: str) -> str:
     """获取插件的上传时间"""
-    if data := get_pypi_data(project_link):
-        if len(data["urls"]) != 0:
-            return data["urls"][0]["upload_time_iso_8601"]
+    data = get_pypi_data(project_link)
+    return data["urls"][0]["upload_time_iso_8601"]

--- a/tests/utils/store_test/test_store_test.py
+++ b/tests/utils/store_test/test_store_test.py
@@ -263,3 +263,136 @@ async def test_store_test_with_key_not_in_previous(
     assert not mocked_api["project_link_wordcloud"].called
     assert not mocked_api["project_link_treehelp"].called
     assert not mocked_api["project_link_datastore"].called
+
+
+async def test_store_test_raise(
+    mocked_store_data: dict[str, Path], mocked_api: MockRouter, mocker: MockerFixture
+):
+    """测试插件，但是测试过程中报错
+
+    第一个插件因为版本号无变化跳过
+    第二插件测试中报错跳过
+    第三个插件测试中也报错
+
+    最后数据没有变化
+    """
+    from src.utils.store_test.store import StoreTest
+
+    mocked_validate_plugin = mocker.patch("src.utils.store_test.store.validate_plugin")
+    mocked_validate_plugin.side_effect = Exception
+
+    test = StoreTest(0, 1, False)
+    await test.run()
+
+    mocked_validate_plugin.assert_has_calls(
+        [
+            mocker.call(
+                plugin={
+                    "module_name": "nonebot_plugin_treehelp",
+                    "project_link": "nonebot-plugin-treehelp",
+                    "author": "he0119",
+                    "tags": [],
+                    "is_official": False,
+                },
+                config="",
+                skip_test=False,
+                previous_plugin={
+                    "module_name": "nonebot_plugin_treehelp",
+                    "project_link": "nonebot-plugin-treehelp",
+                    "name": "帮助",
+                    "desc": "获取插件帮助信息",
+                    "author": "he0119",
+                    "homepage": "https://github.com/he0119/nonebot-plugin-treehelp",
+                    "tags": [],
+                    "is_official": False,
+                    "type": "application",
+                    "supported_adapters": None,
+                    "valid": True,
+                    "time": "2023-06-22 12:10:18",
+                },
+            ),
+            mocker.call(
+                plugin={
+                    "module_name": "nonebot_plugin_wordcloud",
+                    "project_link": "nonebot-plugin-wordcloud",
+                    "author": "he0119",
+                    "tags": [],
+                    "is_official": False,
+                },
+                config="",
+                skip_test=False,
+                previous_plugin=None,
+            ),  # type: ignore
+        ],
+    )
+
+    # 数据没有更新，只是被压缩
+    assert (
+        mocked_store_data["results"].read_text(encoding="utf8")
+        == '{"nonebot-plugin-datastore:nonebot_plugin_datastore":{"time":"2023-06-26T22:08:18.945584+08:00","version":"1.0.0","results":{"validation":true,"load":true,"metadata":true},"inputs":{"config":""},"outputs":{"validation":"通过","load":"datastore","metadata":{"name":"数据存储","description":"NoneBot 数据存储插件","usage":"请参考文档","type":"library","homepage":"https://github.com/he0119/nonebot-plugin-datastore","supported_adapters":null}}},"nonebot-plugin-treehelp:nonebot_plugin_treehelp":{"time":"2023-06-26T22:20:41.833311+08:00","version":"0.3.0","results":{"validation":true,"load":true,"metadata":true},"inputs":{"config":""},"outputs":{"validation":"通过","load":"treehelp","metadata":{"name":"帮助","description":"获取插件帮助信息","usage":"获取插件列表\\n/help\\n获取插件树\\n/help -t\\n/help --tree\\n获取某个插件的帮助\\n/help 插件名\\n获取某个插件的树\\n/help --tree 插件名\\n","type":"application","homepage":"https://github.com/he0119/nonebot-plugin-treehelp","supported_adapters":null}}}}'
+    )
+    assert (
+        mocked_store_data["adapters"].read_text(encoding="utf8")
+        == '[{"module_name":"nonebot.adapters.onebot.v11","project_link":"nonebot-adapter-onebot","name":"OneBot V11","desc":"OneBot V11 协议","author":"yanyongyu","homepage":"https://onebot.adapters.nonebot.dev/","tags":[],"is_official":true}]'
+    )
+    assert (
+        mocked_store_data["bots"].read_text(encoding="utf8")
+        == '[{"name":"CoolQBot","desc":"基于 NoneBot2 的聊天机器人","author":"he0119","homepage":"https://github.com/he0119/CoolQBot","tags":[],"is_official":false}]'
+    )
+    assert (
+        mocked_store_data["drivers"].read_text(encoding="utf8")
+        == '[{"module_name":"~none","project_link":"","name":"None","desc":"None 驱动器","author":"yanyongyu","homepage":"/docs/advanced/driver","tags":[],"is_official":true},{"module_name":"~fastapi","project_link":"nonebot2[fastapi]","name":"FastAPI","desc":"FastAPI 驱动器","author":"yanyongyu","homepage":"/docs/advanced/driver","tags":[],"is_official":true}]'
+    )
+    assert (
+        mocked_store_data["plugins"].read_text(encoding="utf8")
+        == '[{"module_name":"nonebot_plugin_datastore","project_link":"nonebot-plugin-datastore","name":"数据存储","desc":"NoneBot 数据存储插件","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-datastore","tags":[],"is_official":false,"type":"library","supported_adapters":null,"valid":true,"time":"2023-06-22 11:58:18"},{"module_name":"nonebot_plugin_treehelp","project_link":"nonebot-plugin-treehelp","name":"帮助","desc":"获取插件帮助信息","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-treehelp","tags":[],"is_official":false,"type":"application","supported_adapters":null,"valid":true,"time":"2023-06-22 12:10:18"}]'
+    )
+
+
+async def test_store_test_with_key_raise(
+    mocked_store_data: dict[str, Path], mocked_api: MockRouter, mocker: MockerFixture
+):
+    """测试指定插件，但是测试过程中报错"""
+    from src.utils.store_test.store import StoreTest
+
+    mocked_validate_plugin = mocker.patch("src.utils.store_test.store.validate_plugin")
+    mocked_validate_plugin.side_effect = Exception
+
+    test = StoreTest(0, 1, False)
+    await test.run(key="nonebot-plugin-wordcloud:nonebot_plugin_wordcloud")
+
+    mocked_validate_plugin.assert_called_once_with(
+        plugin={
+            "module_name": "nonebot_plugin_wordcloud",
+            "project_link": "nonebot-plugin-wordcloud",
+            "author": "he0119",
+            "tags": [],
+            "is_official": False,
+        },
+        config="",
+        skip_test=False,
+        data=None,
+        previous_plugin=None,
+    )
+
+    # 数据没有更新，只是被压缩
+    assert (
+        mocked_store_data["results"].read_text(encoding="utf8")
+        == '{"nonebot-plugin-datastore:nonebot_plugin_datastore":{"time":"2023-06-26T22:08:18.945584+08:00","version":"1.0.0","results":{"validation":true,"load":true,"metadata":true},"inputs":{"config":""},"outputs":{"validation":"通过","load":"datastore","metadata":{"name":"数据存储","description":"NoneBot 数据存储插件","usage":"请参考文档","type":"library","homepage":"https://github.com/he0119/nonebot-plugin-datastore","supported_adapters":null}}},"nonebot-plugin-treehelp:nonebot_plugin_treehelp":{"time":"2023-06-26T22:20:41.833311+08:00","version":"0.3.0","results":{"validation":true,"load":true,"metadata":true},"inputs":{"config":""},"outputs":{"validation":"通过","load":"treehelp","metadata":{"name":"帮助","description":"获取插件帮助信息","usage":"获取插件列表\\n/help\\n获取插件树\\n/help -t\\n/help --tree\\n获取某个插件的帮助\\n/help 插件名\\n获取某个插件的树\\n/help --tree 插件名\\n","type":"application","homepage":"https://github.com/he0119/nonebot-plugin-treehelp","supported_adapters":null}}}}'
+    )
+    assert (
+        mocked_store_data["adapters"].read_text(encoding="utf8")
+        == '[{"module_name":"nonebot.adapters.onebot.v11","project_link":"nonebot-adapter-onebot","name":"OneBot V11","desc":"OneBot V11 协议","author":"yanyongyu","homepage":"https://onebot.adapters.nonebot.dev/","tags":[],"is_official":true}]'
+    )
+    assert (
+        mocked_store_data["bots"].read_text(encoding="utf8")
+        == '[{"name":"CoolQBot","desc":"基于 NoneBot2 的聊天机器人","author":"he0119","homepage":"https://github.com/he0119/CoolQBot","tags":[],"is_official":false}]'
+    )
+    assert (
+        mocked_store_data["drivers"].read_text(encoding="utf8")
+        == '[{"module_name":"~none","project_link":"","name":"None","desc":"None 驱动器","author":"yanyongyu","homepage":"/docs/advanced/driver","tags":[],"is_official":true},{"module_name":"~fastapi","project_link":"nonebot2[fastapi]","name":"FastAPI","desc":"FastAPI 驱动器","author":"yanyongyu","homepage":"/docs/advanced/driver","tags":[],"is_official":true}]'
+    )
+    assert (
+        mocked_store_data["plugins"].read_text(encoding="utf8")
+        == '[{"module_name":"nonebot_plugin_datastore","project_link":"nonebot-plugin-datastore","name":"数据存储","desc":"NoneBot 数据存储插件","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-datastore","tags":[],"is_official":false,"type":"library","supported_adapters":null,"valid":true,"time":"2023-06-22 11:58:18"},{"module_name":"nonebot_plugin_treehelp","project_link":"nonebot-plugin-treehelp","name":"帮助","desc":"获取插件帮助信息","author":"he0119","homepage":"https://github.com/he0119/nonebot-plugin-treehelp","tags":[],"is_official":false,"type":"application","supported_adapters":null,"valid":true,"time":"2023-06-22 12:10:18"}]'
+    )

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -165,7 +165,7 @@ async def test_validate_plugin_with_data(
         "type": "application",
         "time": "2023-09-01T00:00:00+00:00Z",
         "valid": True,
-        "version": None,
+        "version": "0.0.1",
         "skip_test": True,
     }
 


### PR DESCRIPTION
同时测试结果与插件数据做区分。

测试结果中的 version 字段使用从插件加载测试输出中提取出的版本号，如果跳过测试或无法提取到版本号则为 None。

插件数据中的 version 字段则根据情况，优先使用测试中提取的版本号，如果无法提取出版本号（创建环境失败），则使用 pypi 上的数据。