### PR TITLE
fix: 修复验证出错时无法更新插件版本信息的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复验证出错时无法更新插件版本信息的问题
+
 ## [3.0.6] - 2023-09-07
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ skip_gitignore = true
 
 [tool.ruff]
 select = ["E", "W", "F", "UP", "C", "T", "PYI", "Q"]
-ignore = ["E402", "E501", "C901", "UP037", "T201"]
+ignore = ["E402", "E501", "C901", "UP037"]
 
 [tool.pyright]
 typeCheckingMode = "basic"

--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -8,6 +8,7 @@
 
 经测试可以直接在 Python 3.10+ 环境下运行，无需额外依赖。
 """
+# ruff: noqa: T201
 
 import json
 import os

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -142,8 +142,15 @@ async def validate_plugin(
 
         validation_info_result = validate_info(PublishType.PLUGIN, raw_data)
 
+        # 如果验证失败，则使用上次的插件数据
         if validation_info_result["valid"]:
-            new_plugin = validation_info_result["data"]
+            new_plugin = cast(Plugin, validation_info_result["data"])
+        elif previous_plugin:
+            new_plugin = previous_plugin
+        else:
+            new_plugin = None
+
+        if new_plugin:
             # 插件验证过程中无法获取是否是官方插件，因此需要从原始数据中获取
             new_plugin["is_official"] = is_official
             new_plugin["valid"] = validation_info_result["valid"]
@@ -151,9 +158,6 @@ async def validate_plugin(
             new_plugin["version"] = test_version or pypi_version
             new_plugin["time"] = pypi_time
             new_plugin["skip_test"] = should_skip
-            new_plugin = cast(Plugin, new_plugin)
-        else:
-            new_plugin = None
 
         validation_result = validation_info_result["valid"]
         validation_output = (

--- a/tests/utils/store_test/test_store_test.py
+++ b/tests/utils/store_test/test_store_test.py
@@ -135,6 +135,7 @@ async def test_store_test(
         },
         config="",
         skip_test=False,
+        data=None,
         previous_plugin={
             "module_name": "nonebot_plugin_treehelp",
             "project_link": "nonebot-plugin-treehelp",
@@ -296,6 +297,7 @@ async def test_store_test_raise(
                 },
                 config="",
                 skip_test=False,
+                data=None,
                 previous_plugin={
                     "module_name": "nonebot_plugin_treehelp",
                     "project_link": "nonebot-plugin-treehelp",
@@ -321,6 +323,7 @@ async def test_store_test_raise(
                 },
                 config="",
                 skip_test=False,
+                data=None,
                 previous_plugin=None,
             ),  # type: ignore
         ],


### PR DESCRIPTION
即使验证出错，也应该更新插件信息。比如版本，时间，验证结果与是否还需跳过测试。