### PR TITLE
fix: 等待 2 分钟后再触发 registry_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 等待 2 分钟后再触发 registry_update
+
 ## [3.2.0] - 2023-10-21
 
 ### Added

--- a/src/plugins/publish/__init__.py
+++ b/src/plugins/publish/__init__.py
@@ -122,8 +122,8 @@ async def handle_pr_close(
 
         # 如果商店更新则触发 registry 更新
         if event.payload.pull_request.merged:
-            # GitHub 的缓存一般 1 分钟左右会刷新
-            await asyncio.sleep(60)
+            # GitHub 的缓存一般 2 分钟左右会刷新
+            await asyncio.sleep(delay=120)
             await trigger_registry_update(bot, repo_info, publish_type, issue)
         else:
             logger.info("拉取请求未合并，跳过触发商店列表更新")

--- a/src/plugins/publish/__init__.py
+++ b/src/plugins/publish/__init__.py
@@ -120,10 +120,10 @@ async def handle_pr_close(
         else:
             logger.info("发布的拉取请求未合并，已跳过")
 
-        # GitHub 的缓存一般 1 分钟左右会刷新
-        await asyncio.sleep(60)
         # 如果商店更新则触发 registry 更新
         if event.payload.pull_request.merged:
+            # GitHub 的缓存一般 1 分钟左右会刷新
+            await asyncio.sleep(60)
             await trigger_registry_update(bot, repo_info, publish_type, issue)
         else:
             logger.info("拉取请求未合并，跳过触发商店列表更新")

--- a/src/plugins/publish/__init__.py
+++ b/src/plugins/publish/__init__.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from nonebot import logger, on_type
 from nonebot.adapters.github import (
     GitHubBot,
@@ -118,6 +120,8 @@ async def handle_pr_close(
         else:
             logger.info("发布的拉取请求未合并，已跳过")
 
+        # GitHub 的缓存一般 1 分钟左右会刷新
+        await asyncio.sleep(60)
         # 如果商店更新则触发 registry 更新
         if event.payload.pull_request.merged:
             await trigger_registry_update(bot, repo_info, publish_type, issue)

--- a/src/plugins/publish/__init__.py
+++ b/src/plugins/publish/__init__.py
@@ -123,7 +123,7 @@ async def handle_pr_close(
         # 如果商店更新则触发 registry 更新
         if event.payload.pull_request.merged:
             # GitHub 的缓存一般 2 分钟左右会刷新
-            await asyncio.sleep(delay=120)
+            await asyncio.sleep(120)
             await trigger_registry_update(bot, repo_info, publish_type, issue)
         else:
             logger.info("拉取请求未合并，跳过触发商店列表更新")

--- a/src/plugins/publish/__init__.py
+++ b/src/plugins/publish/__init__.py
@@ -95,12 +95,6 @@ async def handle_pr_close(
             )
         logger.info(f"议题 #{related_issue_number} 已关闭")
 
-        # 如果商店更新则触发 registry 更新
-        if event.payload.pull_request.merged:
-            await trigger_registry_update(bot, repo_info, publish_type, issue)
-        else:
-            logger.info("拉取请求未合并，跳过触发商店列表更新")
-
         try:
             run_shell_command(
                 [
@@ -123,6 +117,12 @@ async def handle_pr_close(
             await resolve_conflict_pull_requests(pull_requests)
         else:
             logger.info("发布的拉取请求未合并，已跳过")
+
+        # 如果商店更新则触发 registry 更新
+        if event.payload.pull_request.merged:
+            await trigger_registry_update(bot, repo_info, publish_type, issue)
+        else:
+            logger.info("拉取请求未合并，跳过触发商店列表更新")
 
 
 async def check_rule(

--- a/tests/publish/process/test_pull_request.py
+++ b/tests/publish/process/test_pull_request.py
@@ -17,6 +17,7 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
     event_path = Path(__file__).parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_sleep = mocker.patch("asyncio.sleep")
 
     mock_issue = mocker.MagicMock()
     mock_issue.state = "open"
@@ -74,6 +75,11 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
             True,
         )
         ctx.should_call_api(
+            "rest.pulls.async_list",
+            {"owner": "he0119", "repo": "action-test", "state": "open"},
+            mock_pulls_resp,
+        )
+        ctx.should_call_api(
             "rest.issues.async_list_comments",
             {"owner": "he0119", "repo": "action-test", "issue_number": 80},
             mock_list_comments_resp,
@@ -91,11 +97,6 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
                 },
             },
             True,
-        )
-        ctx.should_call_api(
-            "rest.pulls.async_list",
-            {"owner": "he0119", "repo": "action-test", "state": "open"},
-            mock_pulls_resp,
         )
 
         ctx.receive_event(bot, event)
@@ -116,6 +117,8 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
         ],  # type: ignore
         any_order=True,
     )
+
+    mock_sleep.assert_awaited_once_with(60)
 
 
 async def test_process_pull_request_not_merged(app: App, mocker: MockerFixture) -> None:
@@ -199,6 +202,7 @@ async def test_process_pull_request_skip_plugin_test(
     event_path = Path(__file__).parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_sleep = mocker.patch("asyncio.sleep")
 
     mock_issue = mocker.MagicMock()
     mock_issue.state = "open"
@@ -258,6 +262,11 @@ async def test_process_pull_request_skip_plugin_test(
             True,
         )
         ctx.should_call_api(
+            "rest.pulls.async_list",
+            {"owner": "he0119", "repo": "action-test", "state": "open"},
+            mock_pulls_resp,
+        )
+        ctx.should_call_api(
             "rest.issues.async_list_comments",
             {"owner": "he0119", "repo": "action-test", "issue_number": 80},
             mock_list_comments_resp,
@@ -276,11 +285,6 @@ async def test_process_pull_request_skip_plugin_test(
                 },
             },
             True,
-        )
-        ctx.should_call_api(
-            "rest.pulls.async_list",
-            {"owner": "he0119", "repo": "action-test", "state": "open"},
-            mock_pulls_resp,
         )
 
         ctx.receive_event(bot, event)
@@ -301,6 +305,8 @@ async def test_process_pull_request_skip_plugin_test(
         ],  # type: ignore
         any_order=True,
     )
+
+    mock_sleep.assert_awaited_once_with(60)
 
 
 async def test_not_publish(app: App, mocker: MockerFixture) -> None:

--- a/tests/publish/process/test_pull_request.py
+++ b/tests/publish/process/test_pull_request.py
@@ -18,6 +18,7 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
 
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_sleep = mocker.patch("asyncio.sleep")
+    mock_sleep.return_value = None
 
     mock_issue = mocker.MagicMock()
     mock_issue.state = "open"
@@ -203,6 +204,7 @@ async def test_process_pull_request_skip_plugin_test(
 
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_sleep = mocker.patch("asyncio.sleep")
+    mock_sleep.return_value = None
 
     mock_issue = mocker.MagicMock()
     mock_issue.state = "open"

--- a/tests/publish/process/test_pull_request.py
+++ b/tests/publish/process/test_pull_request.py
@@ -119,7 +119,7 @@ async def test_process_pull_request(app: App, mocker: MockerFixture) -> None:
         any_order=True,
     )
 
-    mock_sleep.assert_awaited_once_with(60)
+    mock_sleep.assert_awaited_once_with(120)
 
 
 async def test_process_pull_request_not_merged(app: App, mocker: MockerFixture) -> None:
@@ -308,7 +308,7 @@ async def test_process_pull_request_skip_plugin_test(
         any_order=True,
     )
 
-    mock_sleep.assert_awaited_once_with(60)
+    mock_sleep.assert_awaited_once_with(120)
 
 
 async def test_not_publish(app: App, mocker: MockerFixture) -> None:


### PR DESCRIPTION
先处理pr再触发registry更新

有时已经在进行商店更新，但是pr还未合并，nonebot仓库的{module_name}.json未写入新的插件信息，从而导致测试失败
如果没有其它pr触发，就无法写入到 nonebot/registry，导致丢失插件

https://github.com/nonebot/registry/actions/runs/7675902162/job/20922746791
```python3
...
  File "/home/runner/work/registry/registry/src/utils/store_test/store.py", line 96, in test_plugins
    test_plugins = [(key, self._store_plugins[key])]
KeyError: 'nonebot-plugin-nezha:nonebot_plugin_nezha'
```