### PR TITLE
fix: 修复项目名不用 - 分割时无法提取到版本的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复项目名不用 - 分割时无法提取到版本的问题
+
 ## [3.2.3] - 2024-02-01
 
 ### Fixed

--- a/src/utils/store_test/validation.py
+++ b/src/utils/store_test/validation.py
@@ -36,6 +36,8 @@ def extract_version(path: Path, project_link: str) -> str | None:
         return match.group(1).strip()
 
     # 匹配版本解析失败的情况
+    # 目前有很多插件都把信息填错了，没有使用 - 而是使用了 _
+    project_link = project_link.replace("_", "-")
     match = re.search(
         rf"depends on {project_link} \(\^(\S+)\), version solving failed\.", output
     )

--- a/tests/utils/store_test/test_extract_version.py
+++ b/tests/utils/store_test/test_extract_version.py
@@ -61,6 +61,10 @@ def test_extract_version_failed(tmp_path: Path):
 
     assert version == "0.2.1"
 
+    version = extract_version(tmp_path, "nonebot_plugin_mockingbird")
+
+    assert version == "0.2.1"
+
     version = extract_version(tmp_path, "nonebot2")
 
     assert version is None


### PR DESCRIPTION
目前有很多插件都把信息填错了，没有使用 - 而是使用了 _。