### PR TITLE
fix: 插件测试时设置为 10 分钟超时

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复指定 key 时无法正确读取配置的问题
+- 插件测试时设置为 10 分钟超时
 
 ## [3.2.4] - 2024-02-04
 

--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -10,6 +10,7 @@
 """
 # ruff: noqa: T201, ASYNC101
 
+import asyncio
 import json
 import os
 import re
@@ -245,15 +246,21 @@ class PluginTest:
                     )
                 )
 
-            proc = await create_subprocess_shell(
-                "poetry run python runner.py",
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                cwd=self.path,
-                env=self.get_env(),
-            )
-            stdout, stderr = await proc.communicate()
-            code = proc.returncode
+            try:
+                proc = await create_subprocess_shell(
+                    "poetry run python runner.py",
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    cwd=self.path,
+                    env=self.get_env(),
+                )
+                stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=600)
+                code = proc.returncode
+            except asyncio.TimeoutError:
+                proc.terminate()
+                stdout = b""
+                stderr = "测试超时".encode()
+                code = 1
 
             self._run = not code
 


### PR DESCRIPTION
防止有些插件在运行中卡住。