### PR TITLE
feat: 默认使用 fake 适配器

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Added
 
 - 使用 Pydantic 2.0
+- 默认使用 fake 适配器
 
 ### Fixed
 

--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -30,9 +30,60 @@ CONFIG_PATTERN = re.compile(r"### 插件配置项\s+```(?:\w+)?\s?([\s\S]*?)```"
 
 RUNNER = """import json
 import os
+from typing import override
 
-from nonebot import init, load_plugin, require, logger
+from nonebot import init, load_plugin, logger, require
+from nonebot.drivers import (
+    ASGIMixin,
+    HTTPClientMixin,
+    Request,
+    Response,
+    WebSocketClientMixin,
+)
+from nonebot.drivers import Driver as BaseDriver
 from pydantic import BaseModel
+
+
+class Driver(BaseDriver, ASGIMixin, HTTPClientMixin, WebSocketClientMixin):
+    @property
+    @override
+    def type(self) -> str:
+        return "fake"
+
+    @property
+    @override
+    def logger(self):
+        return logger
+
+    @override
+    def run(self, *args, **kwargs):
+        super().run(*args, **kwargs)
+
+    @property
+    @override
+    def server_app(self):
+        raise NotImplementedError
+
+    @property
+    @override
+    def asgi(self):
+        raise NotImplementedError
+
+    @override
+    def setup_http_server(self, setup):
+        raise NotImplementedError
+
+    @override
+    def setup_websocket_server(self, setup):
+        raise NotImplementedError
+
+    @override
+    async def request(self, setup: Request) -> Response:
+        raise NotImplementedError
+
+    @override
+    async def websocket(self, setup: Request) -> Response:
+        raise NotImplementedError
 
 
 class SetEncoder(json.JSONEncoder):
@@ -41,7 +92,8 @@ class SetEncoder(json.JSONEncoder):
             return list(obj)
         return json.JSONEncoder.default(self, obj)
 
-init()
+
+init(driver="runner")
 plugin = load_plugin("{}")
 
 if not plugin:


### PR DESCRIPTION
防止测试中出现类似报错。

```log
插件 nonebot_plugin_nai3 加载出错：
    04-16 03:42:49 [SUCCESS] nonebot | NoneBot is initializing...
    04-16 03:42:49 [INFO] nonebot | Current Env: prod
    04-16 03:42:49 [SUCCESS] nonebot | Succeeded to load plugin "nonebot_plugin_smms"
    04-16 03:42:49 [ERROR] nonebot | Failed to import "nonebot_plugin_nai3"
    04-16 03:32:55 [SUCCESS] nonebot | NoneBot is initializing...
    04-16 03:32:55 [INFO] nonebot | Current Env: prod
    04-16 03:32:56 [SUCCESS] nonebot | Succeeded to load plugin "nonebot_plugin_smms"
    04-16 03:32:56 [ERROR] nonebot | Failed to import "nonebot_plugin_nai3"
    Traceback (most recent call last):
      File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/runner.py", line 15, in <module>
        plugin = load_plugin("nonebot_plugin_nai3")
      File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/.venv/lib/python3.10/site-packages/nonebot/plugin/load.py", line 39, in load_plugin
        return manager.load_plugin(module_path)
    > File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/.venv/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 142, in load_plugin
        module = importlib.import_module(name)
      File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
      File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
      File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
      File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/.venv/lib/python3.10/site-packages/nonebot/plugin/manager.py", line 242, in exec_module
        super().exec_module(module)
      File "<frozen importlib._bootstrap_external>", line 883, in exec_module
      File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/.venv/lib/python3.10/site-packages/nonebot_plugin_nai3/__init__.py", line 41, in <module>
        smms = SMMS()
      File "/home/runner/work/nonebot2/nonebot2/plugin_test/nonebot-plugin-nai3-nonebot_plugin_nai3-test/.venv/lib/python3.10/site-packages/nonebot_plugin_smms/smms.py", line 24, in __init__
        raise RuntimeError(
    RuntimeError: Current driver {'driver': '~none', 'host': IPv4Address('127.0.0.1'), 'port': 8080, 'log_level': 'INFO', 'api_timeout': 30.0, 'superusers': set(), 'nickname': set(), 'command_start': {'/'}, 'command_sep': {'.'}, 'session_expire_timeout': datetime.timedelta(seconds=120), 'nai3_token': 'xxx'} does not support http client requests! sm.ms plugin requires HTTPClient driver.
```

<https://github.com/mobyw/nonebot-plugin-smms/blob/07fe3b48307cad05789d4090f87e7b89b4c2cac8/nonebot_plugin_smms/smms.py#L21-L32>

```
    def __init__(self):
        driver = get_driver()
        if not isinstance(driver, HTTPClientMixin):
            raise RuntimeError(
                f"Current driver {driver.config.dict()} does not support "
                "http client requests! "
                "sm.ms plugin requires HTTPClient driver."
            )
```