### PR TITLE
fix: 使用当前环境的 Python 版本进行测试

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - 修复指定 key 时无法正确读取配置的问题
 - 插件测试时设置为 10 分钟超时
+- 使用当前环境的 Python 版本进行测试
 
 ## [3.2.4] - 2024-02-04
 

--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -213,13 +213,18 @@ class PluginTest:
         env.pop("VIRTUAL_ENV", None)
         # 启用 LOGURU 的颜色输出
         env["LOGURU_COLORIZE"] = "true"
+        # Poetry 配置
+        # https://python-poetry.org/docs/configuration/#virtualenvsin-project
+        env["POETRY_VIRTUALENVS_IN_PROJECT"] = "true"
+        # https://python-poetry.org/docs/configuration/#virtualenvsprefer-active-python-experimental
+        env["POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON"] = "true"
         return env
 
     async def create_poetry_project(self) -> None:
         if not self.path.exists():
             self.path.mkdir()
             proc = await create_subprocess_shell(
-                f"""poetry init -n && sed -i "s/\\^/~/g" pyproject.toml && poetry config virtualenvs.in-project true --local && poetry env info --ansi && poetry add {self.project_link}""",
+                f"""poetry init -n && sed -i "s/\\^/~/g" pyproject.toml && poetry env info --ansi && poetry add {self.project_link}""",
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=self.path,


### PR DESCRIPTION
之前虽然将 Actions 中的 Python 版本升级了，但插件测试时仍然使用安装 Poetry 时的 Python 3.10 进行测试。