### PR TITLE
fix(plugin_test): 调整测试时 Fake 驱动器设置位置

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复 Fake Driver 的 server_app 方法抛出异常导致部分插件测试报错的问题
+- 调整测试时 Fake 驱动器设置位置
 
 ## [3.3.0] - 2024-04-16
 

--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -97,7 +97,7 @@ class SetEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-init(driver="fake")
+init()
 plugin = load_plugin("{}")
 
 if not plugin:
@@ -290,9 +290,9 @@ class PluginTest:
 
     async def run_poetry_project(self) -> None:
         if self.path.exists():
-            # 默认使用 ~none 驱动
+            # 默认使用 fake 驱动
             with open(self.path / ".env", "w", encoding="utf8") as f:
-                f.write("DRIVER=~none")
+                f.write("DRIVER=fake")
             # 如果提供了插件配置项，则写入配置文件
             if self.config is not None:
                 with open(self.path / ".env.prod", "w", encoding="utf8") as f:


### PR DESCRIPTION
驱动器应该通过 .env 文件设置，而不是在 init 的参数中设置。