### PR TITLE
fix(plugin_test): 修复 NoneBot 2.3.0 添加的 HTTP 客户端会话支持导致测试失败的问题

### DIFF
--- a/src/utils/plugin_test.py
+++ b/src/utils/plugin_test.py
@@ -29,15 +29,24 @@ PROJECT_LINK_PATTERN = re.compile(ISSUE_PATTERN.format("PyPI 项目名"))
 MODULE_NAME_PATTERN = re.compile(ISSUE_PATTERN.format("插件 import 包名"))
 CONFIG_PATTERN = re.compile(r"### 插件配置项\s+```(?:\w+)?\s?([\s\S]*?)```")
 
-FAKE_SCRIPT = """from nonebot import logger
+FAKE_SCRIPT = """from typing import Optional, Union
+
+from nonebot import logger
 from nonebot.drivers import (
     ASGIMixin,
     HTTPClientMixin,
+    HTTPClientSession,
+    HTTPVersion,
     Request,
     Response,
     WebSocketClientMixin,
 )
 from nonebot.drivers import Driver as BaseDriver
+from nonebot.internal.driver.model import (
+    CookieTypes,
+    HeaderTypes,
+    QueryTypes,
+)
 from typing_extensions import override
 
 
@@ -80,6 +89,18 @@ class Driver(BaseDriver, ASGIMixin, HTTPClientMixin, WebSocketClientMixin):
 
     @override
     async def websocket(self, setup: Request) -> Response:
+        raise NotImplementedError
+
+    @override
+    def get_session(
+        self,
+        params: QueryTypes = None,
+        headers: HeaderTypes = None,
+        cookies: CookieTypes = None,
+        version: Union[str, HTTPVersion] = HTTPVersion.H11,
+        timeout: Optional[float] = None,
+        proxy: Optional[str] = None,
+    ) -> HTTPClientSession:
         raise NotImplementedError
 """
 


### PR DESCRIPTION
由于 `NoneBot 2.3.0` 对 `HTTPClientMixin` 基类新增了抽象方法 `get_session`，所以现有的 `fake driver` 会导致启动混合驱动类时报错
```
    05-01 20:02:48 [SUCCESS] nonebot | NoneBot is initializing...
    05-01 20:02:48 [INFO] nonebot | Current Env: prod
    Traceback (most recent call last):
      File "/home/runner/work/registry/registry/plugin_test/nonebot-plugin-tetris-stats-nonebot_plugin_tetris_stats-test/runner.py", line 15, in <module>
        init()
      File "/home/runner/work/registry/registry/plugin_test/nonebot-plugin-tetris-stats-nonebot_plugin_tetris_stats-test/.venv/lib/python3.10/site-packages/nonebot/__init__.py", line 319, in init
        _driver = DriverClass(env, config)
    TypeError: Can't instantiate abstract class Driver with abstract method get_session
```