### PR TITLE
fix: 修复主页为空字符串也能通过测试的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复主页为空字符串也能通过测试的问题
+
 ## [3.3.2] - 2024-05-01
 
 ### Added

--- a/src/utils/validation/__init__.py
+++ b/src/utils/validation/__init__.py
@@ -29,7 +29,6 @@ def validate_info(
     if publish_type not in validation_model_map:
         raise ValueError("⚠️ 未知的发布类型。")  # pragma: no cover
 
-    # 如果升级至 pydantic 2 后，可以使用 validation-context
     # https://docs.pydantic.dev/latest/usage/validators/#validation-context
     validation_context = {
         "previous_data": raw_data.get("previous_data"),

--- a/src/utils/validation/constants.py
+++ b/src/utils/validation/constants.py
@@ -27,4 +27,5 @@ MESSAGE_TRANSLATIONS = {
     "color_error": "颜色格式不正确",
     "string_too_long": "字符串长度不能超过 {max_length} 个字符",
     "too_long": "列表长度不能超过 {max_length} 个元素",
+    "string_pattern_mismatch": "字符串应满足格式 '{pattern}'",
 }

--- a/tests/utils/validation/fields/test_homepage.py
+++ b/tests/utils/validation/fields/test_homepage.py
@@ -24,3 +24,28 @@ async def test_homepage_failed_http_exception(mocked_api: MockRouter) -> None:
     ]
 
     assert mocked_api["exception"].called
+
+
+async def test_homepage_failed_empty_homepage(mocked_api: MockRouter) -> None:
+    """主页为空字符串的情况"""
+    from src.utils.validation import PublishType, validate_info
+
+    data = generate_bot_data(homepage="")
+
+    result = validate_info(PublishType.BOT, data)
+
+    assert not result["valid"]
+    assert "homepage" not in result["data"]
+    assert result["errors"] == [
+        {
+            "type": "string_pattern_mismatch",
+            "loc": ("homepage",),
+            "msg": "字符串应满足格式 '^https?://.*$'",
+            "input": "",
+            "ctx": {"pattern": "^https?://.*$"},
+            "url": "https://errors.pydantic.dev/2.7/v/string_pattern_mismatch",
+        }
+    ]
+
+    assert not mocked_api["homepage"].called
+    assert not mocked_api["homepage_failed"].called


### PR DESCRIPTION
限制主页应该为 http 开头的字符串。