### PR TITLE
fix: 使用 PyPI 提供的标准项目名

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复商店数据不能及时同步的问题
+- 使用 PyPI 提供的标准项目名
 
 ## [3.3.3] - 2024-07-18
 

--- a/src/providers/validation/models.py
+++ b/src/providers/validation/models.py
@@ -26,6 +26,7 @@ from .utils import (
     check_pypi,
     check_url,
     get_adapters,
+    get_pypi_name,
     get_upload_time,
     resolve_adapter_name,
 )
@@ -119,6 +120,9 @@ class PyPIMixin(BaseModel):
 
         if v and not check_pypi(v):
             raise PydanticCustomError("project_link.not_found", "PyPI 项目名不存在")
+
+        # 使用 PyPI 提供的标准项目名
+        v = get_pypi_name(v)
         return v
 
     @model_validator(mode="before")

--- a/src/providers/validation/utils.py
+++ b/src/providers/validation/utils.py
@@ -17,6 +17,15 @@ def get_url(url: str) -> httpx.Response:
     return httpx.get(url, follow_redirects=True)
 
 
+def get_pypi_name(project_link: str) -> str:
+    """获取 PyPI 项目名"""
+    url = f"https://pypi.org/pypi/{project_link}/json"
+    r = get_url(url)
+    r.raise_for_status()
+    data = r.json()
+    return data["info"]["name"]
+
+
 def get_upload_time(project_link: str) -> str | None:
     """获取插件的上传时间"""
     url = f"https://pypi.org/pypi/{project_link}/json"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -165,6 +165,15 @@ def mocked_api(respx_mock: MockRouter):
     respx_mock.get(
         "https://pypi.org/pypi/project_link_failed/json", name="project_link_failed"
     ).respond(404)
+    respx_mock.get(
+        "https://pypi.org/pypi/project_link_normalization/json",
+        name="project_link_normalization",
+    ).respond(
+        json={
+            "info": {"name": "project-link-normalization", "version": "0.0.1"},
+            "urls": [{"upload_time_iso_8601": "2023-10-01T00:00:00+00:00Z"}],
+        }
+    )
     respx_mock.get("https://www.baidu.com", name="homepage_failed").respond(404)
     respx_mock.get("https://nonebot.dev/", name="homepage").respond()
     respx_mock.get(STORE_ADAPTERS_URL, name="store_adapters").respond(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,7 +119,7 @@ def mocked_api(respx_mock: MockRouter):
         "https://pypi.org/pypi/project_link/json", name="project_link"
     ).respond(
         json={
-            "info": {"version": "0.0.1"},
+            "info": {"name": "project_link", "version": "0.0.1"},
             "urls": [{"upload_time_iso_8601": "2023-09-01T00:00:00+00:00Z"}],
         }
     )
@@ -127,7 +127,7 @@ def mocked_api(respx_mock: MockRouter):
         "https://pypi.org/pypi/project_link//json", name="project_link/"
     ).respond(
         json={
-            "info": {"version": "0.0.1"},
+            "info": {"name": "project_link/", "version": "0.0.1"},
             "urls": [{"upload_time_iso_8601": "2023-10-01T00:00:00+00:00Z"}],
         }
     )
@@ -136,21 +136,32 @@ def mocked_api(respx_mock: MockRouter):
         name="project_link_treehelp",
     ).respond(
         json={
-            "info": {"version": "0.3.1"},
+            "info": {"name": "nonebot-plugin-treehelp", "version": "0.3.1"},
             "urls": [{"upload_time_iso_8601": "2021-08-01T00:00:00+00:00"}],
         }
     )
     respx_mock.get(
         "https://pypi.org/pypi/nonebot-plugin-datastore/json",
         name="project_link_datastore",
-    ).respond(json={"info": {"version": "1.0.0"}})
+    ).respond(
+        json={
+            "info": {"name": "nonebot-plugin-datastore", "version": "1.0.0"},
+        }
+    )
     respx_mock.get(
         "https://pypi.org/pypi/nonebot-plugin-wordcloud/json",
         name="project_link_wordcloud",
-    ).respond(json={"info": {"version": "0.5.0"}})
+    ).respond(
+        json={"info": {"name": "nonebot-plugin-wordcloud", "version": "0.5.0"}},
+    )
     respx_mock.get(
         "https://pypi.org/pypi/project_link1/json", name="project_link1"
-    ).respond(json={"urls": [{"upload_time_iso_8601": "2023-10-01T00:00:00+00:00Z"}]})
+    ).respond(
+        json={
+            "info": {"name": "project_link1", "version": "0.5.0"},
+            "urls": [{"upload_time_iso_8601": "2023-10-01T00:00:00+00:00Z"}],
+        }
+    )
     respx_mock.get(
         "https://pypi.org/pypi/project_link_failed/json", name="project_link_failed"
     ).respond(404)

--- a/tests/utils/validation/fields/test_pypi.py
+++ b/tests/utils/validation/fields/test_pypi.py
@@ -167,3 +167,33 @@ async def test_name_duplication_previos_data_missing(mocked_api: MockRouter) -> 
 
     assert not mocked_api["project_link1"].called
     assert not mocked_api["homepage"].called
+
+
+async def test_project_link_normalization(mocked_api: MockRouter) -> None:
+    """测试 PyPI 项目名的规范化"""
+    from src.providers.validation import PublishType, validate_info
+
+    data = generate_adapter_data(project_link="project_link_normalization")
+
+    result = validate_info(PublishType.ADAPTER, data, [])
+
+    assert result.valid
+    assert result.type == PublishType.ADAPTER
+    assert result.valid_data == snapshot(
+        {
+            "module_name": "module_name",
+            "project_link": "project-link-normalization",
+            "time": "2023-10-01T00:00:00+00:00Z",
+            "name": "name",
+            "desc": "desc",
+            "author": "author",
+            "author_id": 1,
+            "homepage": "https://nonebot.dev",
+            "tags": [{"label": "test", "color": "#ffffff"}],
+        }
+    )
+    assert result.info
+    assert result.errors == []
+
+    assert mocked_api["homepage"].called
+    assert mocked_api["project_link_normalization"].called


### PR DESCRIPTION
有时候用户会填写不够规范的项目名，此时通过 pypi 也能正确获取到项目信息。
现在在验证的过程中，直接将项目名设置为 pypi 标准的项目名。