### PR TITLE
fix: rule 新增 is_publish_related_workflow

### DIFF
--- a/src/plugins/github/depends/__init__.py
+++ b/src/plugins/github/depends/__init__.py
@@ -100,18 +100,3 @@ def get_type_by_labels_name(
         if type.value in labels:
             return type
     return None
-
-
-async def is_publish_related_workflow(
-    labels: list[str] = Depends(get_labels_name),
-    publish_type: PublishType = Depends(get_type_by_labels_name),
-) -> bool:
-    """是否是发布相关的工作流
-
-    通过标签判断
-    仅包含发布相关标签，不包含 remove 标签
-    """
-    for label in labels:
-        if label == "Remove":
-            return False
-    return True

--- a/src/plugins/github/depends/__init__.py
+++ b/src/plugins/github/depends/__init__.py
@@ -1,6 +1,10 @@
 from nonebot import logger
 from nonebot.adapters.github import (
     GitHubBot,
+    IssueCommentCreated,
+    IssuesEdited,
+    IssuesOpened,
+    IssuesReopened,
     PullRequestClosed,
     PullRequestReviewSubmitted,
 )
@@ -80,9 +84,20 @@ def get_related_issue_number(event: PullRequestClosed) -> int | None:
 
 
 def is_bot_triggered_workflow(event: IssuesEvent):
-    """触发议题相关的工作流"""
-    if event.payload.sender.type == "Bot":
-        logger.info("议题修改来自机器人，已跳过")
+    """是否是机器人触发的工作流"""
+    if (
+        isinstance(event, IssueCommentCreated)
+        and event.payload.comment.user
+        and event.payload.comment.user.type == "Bot"
+    ):
+        logger.info("议题评论来自机器人，已跳过")
+        return True
+    if (
+        isinstance(event, IssuesOpened | IssuesReopened | IssuesEdited)
+        and event.payload.issue.user
+        and event.payload.issue.user.type == "Bot"
+    ):
+        logger.info("议题操作来自机器人，已跳过")
         return True
     return False
 

--- a/src/plugins/github/plugins/publish/__init__.py
+++ b/src/plugins/github/plugins/publish/__init__.py
@@ -22,7 +22,6 @@ from src.plugins.github.depends import (
     get_repo_info,
     install_pre_commit_hooks,
     is_bot_triggered_workflow,
-    is_publish_related_workflow,
 )
 from src.plugins.github.models import GithubHandler, IssueHandler, RepoInfo
 from src.plugins.github.plugins.publish.render import render_comment
@@ -32,6 +31,7 @@ from .depends import (
     get_issue_handler,
     get_related_issue_handler,
     get_type_by_labels_name,
+    is_publish_related_workflow,
 )
 from .utils import (
     ensure_issue_content,

--- a/src/plugins/github/plugins/publish/__init__.py
+++ b/src/plugins/github/plugins/publish/__init__.py
@@ -11,6 +11,7 @@ from nonebot.adapters.github import (
     PullRequestReviewSubmitted,
 )
 from nonebot.params import Arg, Depends
+from nonebot.rule import Rule
 from nonebot.typing import T_State
 
 from src.plugins.github.constants import BRANCH_NAME_PREFIX, TITLE_MAX_LENGTH
@@ -18,6 +19,7 @@ from src.plugins.github.depends import (
     bypass_git,
     get_github_handler,
     get_installation_id,
+    get_labels_name,
     get_related_issue_number,
     get_repo_info,
     install_pre_commit_hooks,
@@ -25,13 +27,13 @@ from src.plugins.github.depends import (
 )
 from src.plugins.github.models import GithubHandler, IssueHandler, RepoInfo
 from src.plugins.github.plugins.publish.render import render_comment
+from src.plugins.github.plugins.remove.constants import REMOVE_LABEL
 from src.providers.validation.models import PublishType, ValidationDict
 
 from .depends import (
     get_issue_handler,
     get_related_issue_handler,
     get_type_by_labels_name,
-    is_publish_related_workflow,
 )
 from .utils import (
     ensure_issue_content,
@@ -47,10 +49,24 @@ from .validation import (
 )
 
 
+async def publish_related_rule(
+    labels: list[str] = Depends(get_labels_name),
+    publish_type: PublishType = Depends(get_type_by_labels_name),
+) -> bool:
+    """确保与发布相关
+
+    通过标签判断
+    仅包含发布相关标签，不包含 remove 标签
+    """
+    for label in labels:
+        if label == REMOVE_LABEL:
+            return False
+    return True
+
+
 async def pr_close_rule(
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
     related_issue_number: int | None = Depends(get_related_issue_number),
-    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if publish_type is None:
         logger.info("拉取请求与发布无关，已跳过")
@@ -63,7 +79,9 @@ async def pr_close_rule(
     return True
 
 
-pr_close_matcher = on_type(PullRequestClosed, rule=pr_close_rule)
+pr_close_matcher = on_type(
+    PullRequestClosed, rule=Rule(pr_close_rule, publish_related_rule)
+)
 
 
 @pr_close_matcher.handle(
@@ -106,7 +124,6 @@ async def check_rule(
     event: IssuesOpened | IssuesReopened | IssuesEdited | IssueCommentCreated,
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
     is_bot: bool = Depends(is_bot_triggered_workflow),
-    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if is_bot:
         logger.info("机器人触发的工作流，已跳过")
@@ -122,7 +139,8 @@ async def check_rule(
 
 
 publish_check_matcher = on_type(
-    (IssuesOpened, IssuesReopened, IssuesEdited, IssueCommentCreated), rule=check_rule
+    (IssuesOpened, IssuesReopened, IssuesEdited, IssueCommentCreated),
+    rule=Rule(check_rule, publish_related_rule),
 )
 
 
@@ -235,7 +253,6 @@ async def handle_pull_request_and_update_issue(
 async def review_submiited_rule(
     event: PullRequestReviewSubmitted,
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
-    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if publish_type is None:
         logger.info("拉取请求与发布无关，已跳过")
@@ -250,7 +267,9 @@ async def review_submiited_rule(
     return True
 
 
-auto_merge_matcher = on_type(PullRequestReviewSubmitted, rule=review_submiited_rule)
+auto_merge_matcher = on_type(
+    PullRequestReviewSubmitted, rule=Rule(review_submiited_rule, publish_related_rule)
+)
 
 
 @auto_merge_matcher.handle(

--- a/src/plugins/github/plugins/publish/__init__.py
+++ b/src/plugins/github/plugins/publish/__init__.py
@@ -22,6 +22,7 @@ from src.plugins.github.depends import (
     get_repo_info,
     install_pre_commit_hooks,
     is_bot_triggered_workflow,
+    is_publish_related_workflow,
 )
 from src.plugins.github.models import GithubHandler, IssueHandler, RepoInfo
 from src.plugins.github.plugins.publish.render import render_comment
@@ -49,6 +50,7 @@ from .validation import (
 async def pr_close_rule(
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
     related_issue_number: int | None = Depends(get_related_issue_number),
+    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if publish_type is None:
         logger.info("拉取请求与发布无关，已跳过")
@@ -104,6 +106,7 @@ async def check_rule(
     event: IssuesOpened | IssuesReopened | IssuesEdited | IssueCommentCreated,
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
     is_bot: bool = Depends(is_bot_triggered_workflow),
+    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if is_bot:
         logger.info("机器人触发的工作流，已跳过")
@@ -232,6 +235,7 @@ async def handle_pull_request_and_update_issue(
 async def review_submiited_rule(
     event: PullRequestReviewSubmitted,
     publish_type: PublishType | None = Depends(get_type_by_labels_name),
+    is_publish_related_workflow: Literal[True] = Depends(is_publish_related_workflow),
 ) -> bool:
     if publish_type is None:
         logger.info("拉取请求与发布无关，已跳过")

--- a/src/plugins/github/plugins/publish/depends.py
+++ b/src/plugins/github/plugins/publish/depends.py
@@ -6,14 +6,12 @@ from src.plugins.github.depends import (
     get_installation_id,
     get_issue_number,
     get_issue_title,
-    get_labels_name,
     get_related_issue_number,
     get_repo_info,
     get_type_by_labels_name,
 )
 from src.plugins.github.models import IssueHandler, RepoInfo
 from src.plugins.github.plugins.publish import utils
-from src.plugins.github.plugins.remove.constants import REMOVE_LABEL
 from src.providers.validation.models import PublishType
 
 
@@ -64,18 +62,3 @@ async def get_related_issue_handler(
     return await get_issue_handler(
         bot, installation_id, repo_info, related_issue_number
     )
-
-
-async def is_publish_related_workflow(
-    labels: list[str] = Depends(get_labels_name),
-    publish_type: PublishType = Depends(get_type_by_labels_name),
-) -> bool:
-    """是否是发布相关的工作流
-
-    通过标签判断
-    仅包含发布相关标签，不包含 remove 标签
-    """
-    for label in labels:
-        if label == REMOVE_LABEL:
-            return False
-    return True

--- a/src/plugins/github/plugins/publish/depends.py
+++ b/src/plugins/github/plugins/publish/depends.py
@@ -6,12 +6,14 @@ from src.plugins.github.depends import (
     get_installation_id,
     get_issue_number,
     get_issue_title,
+    get_labels_name,
     get_related_issue_number,
     get_repo_info,
     get_type_by_labels_name,
 )
 from src.plugins.github.models import IssueHandler, RepoInfo
 from src.plugins.github.plugins.publish import utils
+from src.plugins.github.plugins.remove.constants import REMOVE_LABEL
 from src.providers.validation.models import PublishType
 
 
@@ -62,3 +64,18 @@ async def get_related_issue_handler(
     return await get_issue_handler(
         bot, installation_id, repo_info, related_issue_number
     )
+
+
+async def is_publish_related_workflow(
+    labels: list[str] = Depends(get_labels_name),
+    publish_type: PublishType = Depends(get_type_by_labels_name),
+) -> bool:
+    """是否是发布相关的工作流
+
+    通过标签判断
+    仅包含发布相关标签，不包含 remove 标签
+    """
+    for label in labels:
+        if label == REMOVE_LABEL:
+            return False
+    return True

--- a/tests/github/publish/process/test_auto_merge.py
+++ b/tests/github/publish/process/test_auto_merge.py
@@ -12,8 +12,6 @@ async def test_auto_merge(app: App, mocker: MockerFixture, mock_installation) ->
 
     可直接合并的情况
     """
-    from src.plugins.github.plugins.publish import auto_merge_matcher
-
     mock_subprocess_run = mocker.patch("subprocess.run")
 
     mock_pull = mocker.MagicMock()
@@ -21,7 +19,7 @@ async def test_auto_merge(app: App, mocker: MockerFixture, mock_installation) ->
     mock_pull_resp = mocker.MagicMock()
     mock_pull_resp.parsed_data = mock_pull
 
-    async with app.test_matcher(auto_merge_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent
@@ -82,7 +80,6 @@ async def test_auto_merge_need_rebase(
     需要 rebase 的情况
     """
     from src.plugins.github.models import GithubHandler, RepoInfo
-    from src.plugins.github.plugins.publish import auto_merge_matcher
 
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_resolve_conflict_pull_requests = mocker.patch(
@@ -95,7 +92,7 @@ async def test_auto_merge_need_rebase(
     mock_pull_resp = mocker.MagicMock()
     mock_pull_resp.parsed_data = mock_pull
 
-    async with app.test_matcher(auto_merge_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent
@@ -153,14 +150,12 @@ async def test_auto_merge_not_publish(app: App, mocker: MockerFixture) -> None:
 
     和发布无关
     """
-    from src.plugins.github.plugins.publish import auto_merge_matcher
-
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_resolve_conflict_pull_requests = mocker.patch(
         "src.plugins.github.plugins.publish.resolve_conflict_pull_requests"
     )
 
-    async with app.test_matcher(auto_merge_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent
@@ -185,14 +180,12 @@ async def test_auto_merge_not_member(app: App, mocker: MockerFixture) -> None:
 
     审核者不是仓库成员
     """
-    from src.plugins.github.plugins.publish import auto_merge_matcher
-
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_resolve_conflict_pull_requests = mocker.patch(
         "src.plugins.github.plugins.publish.resolve_conflict_pull_requests"
     )
 
-    async with app.test_matcher(auto_merge_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent
@@ -217,14 +210,12 @@ async def test_auto_merge_not_approve(app: App, mocker: MockerFixture) -> None:
 
     审核未通过
     """
-    from src.plugins.github.plugins.publish import auto_merge_matcher
-
     mock_subprocess_run = mocker.patch("subprocess.run")
     mock_resolve_conflict_pull_requests = mocker.patch(
         "src.plugins.github.plugins.publish.resolve_conflict_pull_requests"
     )
 
-    async with app.test_matcher(auto_merge_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent

--- a/tests/github/publish/process/test_publish_check.py
+++ b/tests/github/publish/process/test_publish_check.py
@@ -29,7 +29,6 @@ async def test_bot_process_publish_check(
 ) -> None:
     """测试机器人的发布流程"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -60,7 +59,7 @@ async def test_bot_process_publish_check(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -221,7 +220,6 @@ async def test_adapter_process_publish_check(
 ) -> None:
     """测试适配器的发布流程"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -252,7 +250,7 @@ async def test_adapter_process_publish_check(
 
     check_json_data(plugin_config.input_config.adapter_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -434,7 +432,6 @@ async def test_edit_title(
     名称被修改后，标题也应该被修改
     """
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -466,7 +463,7 @@ async def test_edit_title(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -656,7 +653,6 @@ async def test_edit_title_too_long(
     标题过长的情况
     """
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -687,7 +683,7 @@ async def test_edit_title_too_long(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -793,7 +789,6 @@ async def test_process_publish_check_not_pass(
 ) -> None:
     """测试发布检查不通过"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -819,7 +814,7 @@ async def test_process_publish_check_not_pass(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -918,13 +913,11 @@ async def test_comment_at_pull_request(
 
     event.issue.pull_request 不为空
     """
-    from src.plugins.github.plugins.publish import publish_check_matcher
-
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
     )
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "pr-comment.json"
         event = Adapter.payload_to_event("1", "issue_comment", event_path.read_bytes())
@@ -943,8 +936,6 @@ async def test_issue_state_closed(
 
     event.issue.state = "closed"
     """
-    from src.plugins.github.plugins.publish import publish_check_matcher
-
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
     )
@@ -953,7 +944,7 @@ async def test_issue_state_closed(
     mock_issues_resp = mocker.MagicMock()
     mock_issues_resp.parsed_data = mock_issue
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -996,13 +987,11 @@ async def test_not_publish_issue(
 
     议题的标签不是 "Bot/Adapter/Plugin"
     """
-    from src.plugins.github.plugins.publish import publish_check_matcher
-
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
     )
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -1018,13 +1007,11 @@ async def test_comment_by_self(
     app: App, mocker: MockerFixture, mocked_api: MockRouter
 ) -> None:
     """测试自己评论触发的情况"""
-    from src.plugins.github.plugins.publish import publish_check_matcher
-
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
     )
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent / "events" / "issue-comment-bot.json"
@@ -1046,7 +1033,6 @@ async def test_skip_plugin_check(
 ) -> None:
     """测试手动跳过插件测试的流程"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -1076,7 +1062,7 @@ async def test_skip_plugin_check(
 
     check_json_data(plugin_config.input_config.plugin_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent / "events" / "issue-comment-skip.json"
@@ -1249,7 +1235,6 @@ async def test_convert_pull_request_to_draft(
 ) -> None:
     """未通过时将拉取请求转换为草稿"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -1281,7 +1266,7 @@ async def test_convert_pull_request_to_draft(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -1391,7 +1376,6 @@ async def test_process_publish_check_ready_for_review(
 ) -> None:
     """当之前失败后再次通过测试时，应该将拉取请求标记为 ready for review"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.publish import publish_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -1425,7 +1409,7 @@ async def test_process_publish_check_ready_for_review(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(publish_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())

--- a/tests/github/publish/process/test_publish_pull_request.py
+++ b/tests/github/publish/process/test_publish_pull_request.py
@@ -21,7 +21,6 @@ async def test_process_pull_request(
     mock_installation,
     mocked_api: MockRouter,
 ) -> None:
-    from src.plugins.github.plugins.publish import pr_close_matcher
     from src.providers.docker_test import Metadata
     from src.providers.validation import PublishType
 
@@ -57,7 +56,7 @@ async def test_process_pull_request(
     mock_docker = mocker.patch("src.providers.docker_test.DockerPluginTest.run")
     mock_docker.return_value = mock_test_result
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
         event = Adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
@@ -173,8 +172,6 @@ async def test_process_pull_request(
 async def test_process_pull_request_not_merged(
     app: App, mocker: MockerFixture, mock_installation
 ) -> None:
-    from src.plugins.github.plugins.publish import pr_close_matcher
-
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
@@ -184,7 +181,7 @@ async def test_process_pull_request_not_merged(
     mock_issues_resp = mocker.MagicMock()
     mock_issues_resp.parsed_data = mock_issue
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)
@@ -235,7 +232,6 @@ async def test_process_pull_request_skip_plugin_test(
     app: App, mocker: MockerFixture, mocked_api: MockRouter, mock_installation
 ) -> None:
     """跳过测试的插件合并时的情况"""
-    from src.plugins.github.plugins.publish import pr_close_matcher
     from src.providers.validation import PublishType
 
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
@@ -263,7 +259,7 @@ async def test_process_pull_request_skip_plugin_test(
     mock_list_comments_resp = mocker.MagicMock()
     mock_list_comments_resp.parsed_data = [mock_comment]
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = Adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)
@@ -377,13 +373,11 @@ async def test_process_pull_request_skip_plugin_test(
 
 async def test_not_publish(app: App, mocker: MockerFixture) -> None:
     """测试与发布无关的拉取请求"""
-    from src.plugins.github.plugins.publish import pr_close_matcher
-
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = Adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)
@@ -399,13 +393,11 @@ async def test_extract_issue_number_from_ref_failed(
     app: App, mocker: MockerFixture
 ) -> None:
     """测试从分支名中提取议题号失败"""
-    from src.plugins.github.plugins.publish import pr_close_matcher
-
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = Adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)

--- a/tests/github/remove/process/test_remove_check.py
+++ b/tests/github/remove/process/test_remove_check.py
@@ -909,6 +909,7 @@ async def test_process_trigger_by_bot(app: App):
         )
         event = Adapter.payload_to_event("1", "issue_comment", event_path.read_bytes())
         assert isinstance(event, IssueCommentCreated)
-        event.payload.sender.type = "Bot"
+        assert event.payload.comment.user
+        event.payload.comment.user.type = "Bot"
 
         ctx.receive_event(bot, event)

--- a/tests/github/remove/process/test_remove_check.py
+++ b/tests/github/remove/process/test_remove_check.py
@@ -30,7 +30,6 @@ async def test_process_remove_bot_check(
 ):
     """测试正常的删除流程"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.remove import remove_check_matcher
 
     data = [
         {
@@ -76,7 +75,7 @@ async def test_process_remove_bot_check(
 
     check_json_data(plugin_config.input_config.bot_path, data)
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -232,7 +231,6 @@ async def test_process_remove_plugin_check(
 ):
     """测试正常的删除流程"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.remove import remove_check_matcher
 
     data = [
         {
@@ -280,7 +278,7 @@ async def test_process_remove_plugin_check(
 
     check_json_data(plugin_config.input_config.plugin_path, data)
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -438,7 +436,6 @@ async def test_process_remove_not_found_check(
 ):
     """要删除的包不在数据文件中的情况"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.remove import remove_check_matcher
 
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
@@ -473,7 +470,7 @@ async def test_process_remove_not_found_check(
 
     check_json_data(plugin_config.input_config.bot_path, [])
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -550,7 +547,6 @@ async def test_process_remove_author_info_not_eq(
 ):
     """删除包时作者信息不相等的问题"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.remove import remove_check_matcher
 
     bot_data = [
         {
@@ -597,7 +593,7 @@ async def test_process_remove_author_info_not_eq(
 
     check_json_data(plugin_config.input_config.bot_path, bot_data)
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -674,7 +670,6 @@ async def test_process_remove_issue_info_not_found(
 ):
     """删除包时无法从议题获取信息的测试"""
     from src.plugins.github import plugin_config
-    from src.plugins.github.plugins.remove import remove_check_matcher
 
     bot_data = [
         {
@@ -719,7 +714,7 @@ async def test_process_remove_issue_info_not_found(
 
     check_json_data(plugin_config.input_config.bot_path, bot_data)
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -795,8 +790,6 @@ async def test_process_remove_driver(
     mock_installation,
 ):
     """不支持驱动器类型的删除"""
-    from src.plugins.github.plugins.remove import remove_check_matcher
-
     mock_subprocess_run = mocker.patch(
         "subprocess.run", side_effect=lambda *args, **kwargs: mocker.MagicMock()
     )
@@ -823,7 +816,7 @@ async def test_process_remove_driver(
     mock_pulls_resp = mocker.MagicMock()
     mock_pulls_resp.parsed_data = mock_pull
 
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "issue-open.json"
         event = Adapter.payload_to_event("1", "issues", event_path.read_bytes())
@@ -891,12 +884,7 @@ async def test_process_remove_driver(
     )
 
 
-async def test_process_not_remove_label(
-    app: App,
-    mocker: MockerFixture,
-    mocked_api: MockRouter,
-    tmp_path: Path,
-):
+async def test_process_not_remove_label(app: App):
     """测试没有删除标签的情况"""
     from src.plugins.github.plugins.remove import remove_check_matcher
 
@@ -912,16 +900,9 @@ async def test_process_not_remove_label(
         ctx.receive_event(bot, event)
 
 
-async def test_process_trigger_by_bot(
-    app: App,
-    mocker: MockerFixture,
-    mocked_api: MockRouter,
-    tmp_path: Path,
-):
+async def test_process_trigger_by_bot(app: App):
     """测试 Bot 触发工作流的情况"""
-    from src.plugins.github.plugins.remove import remove_check_matcher
-
-    async with app.test_matcher(remove_check_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = (
             Path(__file__).parent.parent.parent / "events" / "issue-comment.json"

--- a/tests/github/remove/process/test_remove_pull_request.py
+++ b/tests/github/remove/process/test_remove_pull_request.py
@@ -30,8 +30,6 @@ async def test_remove_process_pull_request(
     app: App, mocker: MockerFixture, mock_installation: MagicMock
 ) -> None:
     """删除流程的拉取请求关闭流程"""
-    from src.plugins.github.plugins.remove import pr_close_matcher
-
     mock_subprocess_run = mocker.patch("subprocess.run")
 
     remove_type = "Bot"
@@ -50,7 +48,7 @@ async def test_remove_process_pull_request(
     mock_list_comments_resp = mocker.MagicMock()
     mock_list_comments_resp.parsed_data = [mock_comment]
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
         event = adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
@@ -111,13 +109,11 @@ async def test_remove_process_pull_request(
 
 async def test_not_remove(app: App, mocker: MockerFixture) -> None:
     """测试与发布无关的拉取请求"""
-    from src.plugins.github.plugins.remove import pr_close_matcher
-
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = Adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)
@@ -133,8 +129,6 @@ async def test_process_remove_pull_request_not_merged(
     app: App, mocker: MockerFixture, mock_installation
 ) -> None:
     """删除掉不合并的分支"""
-    from src.plugins.github.plugins.remove import pr_close_matcher
-
     event_path = Path(__file__).parent.parent.parent / "events" / "pr-close.json"
 
     mock_subprocess_run = mocker.patch("subprocess.run")
@@ -146,7 +140,7 @@ async def test_process_remove_pull_request_not_merged(
     mock_issues_resp = mocker.MagicMock()
     mock_issues_resp.parsed_data = mock_issue
 
-    async with app.test_matcher(pr_close_matcher) as ctx:
+    async with app.test_matcher() as ctx:
         adapter, bot = get_github_bot(ctx)
         event = adapter.payload_to_event("1", "pull_request", event_path.read_bytes())
         assert isinstance(event, PullRequestClosed)


### PR DESCRIPTION
只有当没有 Remove 标签时，才会走发布流程

同时修改了判断 Bot 的方式，仅通过 sender.type 判断