### PR TITLE
fix: 修复插件测试报错的 ctx 异常的问题

### DIFF
--- a/src/providers/validation/models.py
+++ b/src/providers/validation/models.py
@@ -274,7 +274,7 @@ class PluginPublishInfo(PublishInfo, PyPIMixin):
         raise PydanticCustomError(
             "plugin.test",
             "插件无法正常加载",
-            {"output": context.get("plugin_test_output")},
+            {"output": context.get("test_output")},
         )
 
     @field_validator("metadata", mode="before")

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -411,7 +411,12 @@ async def test_validate_plugin_failed_with_previous(
                             "loc": ("load",),
                             "msg": "插件无法正常加载",
                             "input": False,
-                            "ctx": {"output": None},
+                            "ctx": {
+                                "output": """\
+创建测试目录 plugin_test
+        For further information visit https://errors.pydantic.dev/2.9/v/model_type\x1b[0m\
+"""
+                            },
                         },
                     ],
                 },

--- a/tests/utils/validation/test_plugin.py
+++ b/tests/utils/validation/test_plugin.py
@@ -154,7 +154,7 @@ async def test_plugin_info_validation_plugin_load_failed(
                     "loc": ("load",),
                     "msg": "插件无法正常加载",
                     "input": False,
-                    "ctx": {"output": None},
+                    "ctx": {"output": "test_output"},
                 }
             ],
             info=None,


### PR DESCRIPTION
应该是 test_output 而不是 plugin_test_output。