### PR TITLE
fix(store_test): 修复商店测试时标签验证出错的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复商店测试时标签验证出错的问题
+
 ## [4.0.4] - 2024-11-20
 
 ### Fixed

--- a/src/plugins/github/plugins/publish/validation.py
+++ b/src/plugins/github/plugins/publish/validation.py
@@ -43,7 +43,7 @@ def strip_ansi(text: str | None) -> str:
 
 def add_step_summary(summary: str):
     """添加作业摘要"""
-    with plugin_config.github_step_summary.open("a") as f:
+    with plugin_config.github_step_summary.open("a", encoding="utf-8") as f:
         f.write(summary + "\n")
 
 

--- a/src/providers/store_test/validation.py
+++ b/src/providers/store_test/validation.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import click
+from pydantic_core import to_jsonable_python
 
 from src.providers.docker_test import DockerPluginTest
 from src.providers.models import RegistryPlugin, StorePlugin, StoreTestResult
@@ -68,7 +69,8 @@ async def validate_plugin(
         raw_data.update(
             {
                 "author_id": store_plugin.author_id,
-                "tags": store_plugin.tags,
+                # 必须转成 Python 的 dict，如果 tags 为 list[Tag] 无法进行验证
+                "tags": to_jsonable_python(store_plugin.tags),
                 "is_official": store_plugin.is_official,
             }
         )

--- a/src/providers/store_test/validation.py
+++ b/src/providers/store_test/validation.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 import click
-from pydantic_core import to_jsonable_python
 
 from src.providers.docker_test import DockerPluginTest
 from src.providers.models import RegistryPlugin, StorePlugin, StoreTestResult
@@ -69,8 +68,7 @@ async def validate_plugin(
         raw_data.update(
             {
                 "author_id": store_plugin.author_id,
-                # 必须转成 Python 的 dict，如果 tags 为 list[Tag] 无法进行验证
-                "tags": to_jsonable_python(store_plugin.tags),
+                "tags": store_plugin.tags,
                 "is_official": store_plugin.is_official,
             }
         )

--- a/src/providers/validation/__init__.py
+++ b/src/providers/validation/__init__.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from pydantic import ValidationError
-from pydantic_core import ErrorDetails, to_jsonable_python
+from pydantic_core import ErrorDetails
 
 from .models import (
     AdapterPublishInfo,
@@ -61,7 +61,7 @@ def validate_info(
     return ValidationDict(
         type=publish_type,
         raw_data=raw_data,
-        valid_data=to_jsonable_python(context.get("valid_data", {})),
+        valid_data=context.get("valid_data", {}),
         info=info,
         errors=errors,
     )

--- a/src/providers/validation/models.py
+++ b/src/providers/validation/models.py
@@ -187,7 +187,8 @@ class PublishInfo(abc.ABC, BaseModel):
     @classmethod
     def tags_validator(cls, v: str | list[Any]) -> list[dict[str, str]]:
         if not isinstance(v, str):
-            return v
+            # 将值转成 Python dict，避免 model_type 报错
+            return to_jsonable_python(v)
 
         try:
             return load_json(v)

--- a/tests/github/publish/utils/test_validate_info_from_issue.py
+++ b/tests/github/publish/utils/test_validate_info_from_issue.py
@@ -100,7 +100,7 @@ async def test_validate_info_from_issue_plugin(
 
     assert result.valid
     assert mocked_api["homepage"].called
-    assert plugin_config.github_step_summary.read_text() == snapshot(
+    assert plugin_config.github_step_summary.read_text(encoding="utf-8") == snapshot(
         """\
 # 📃 插件 project_link (1.0.0)
 

--- a/tests/utils/store_test/test_validate_plugin.py
+++ b/tests/utils/store_test/test_validate_plugin.py
@@ -104,7 +104,7 @@ async def test_validate_plugin_with_previous(
     需要能够正常更新 author_id, tags 和 is_official 等信息
     """
     from src.providers.docker_test import Metadata
-    from src.providers.models import RegistryPlugin, StoreTestResult
+    from src.providers.models import Color, RegistryPlugin, StoreTestResult, Tag
     from src.providers.store_test.validation import StorePlugin, validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
@@ -119,7 +119,7 @@ async def test_validate_plugin_with_previous(
         module_name="module_name",
         project_link="project_link",
         author_id=1,
-        tags=[],
+        tags=[Tag(label="test", color=Color("ffffff"))],
         is_official=True,
     )
 
@@ -167,23 +167,23 @@ async def test_validate_plugin_with_previous(
         )
     )
 
-    assert new_plugin == snapshot(
-        RegistryPlugin(
-            author="he0119",
-            desc="订阅牛客/CF/AT平台的比赛信息",
-            homepage="https://nonebot.dev/",
-            is_official=True,
-            module_name="module_name",
-            name="TREEHELP",
-            project_link="project_link",
-            skip_test=False,
-            supported_adapters=None,
-            tags=[],
-            time="2023-09-01T00:00:00+00:00Z",
-            type="application",
-            valid=True,
-            version="0.2.0",
-        )
+    assert new_plugin.model_dump() == snapshot(
+        {
+            "module_name": "module_name",
+            "project_link": "project_link",
+            "name": "TREEHELP",
+            "desc": "订阅牛客/CF/AT平台的比赛信息",
+            "author": "he0119",
+            "homepage": "https://nonebot.dev/",
+            "tags": [{"label": "test", "color": "#ffffff"}],
+            "is_official": True,
+            "type": "application",
+            "supported_adapters": None,
+            "valid": True,
+            "time": "2023-09-01T00:00:00+00:00Z",
+            "version": "0.2.0",
+            "skip_test": False,
+        }
     )
 
     assert mocked_api["homepage"].called


### PR DESCRIPTION
tags 必须转成 Python 的 dict，如果为 list[Tag] 无法进行验证。