### PR TITLE
fix(docker_test): 修复插件测试获取到的插件元数据主页为空时报错的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复插件测试获取到的插件元数据主页为空时报错的问题
+
 ## [4.0.6] - 2024-11-20
 
 ### Fixed

--- a/src/providers/docker_test/__init__.py
+++ b/src/providers/docker_test/__init__.py
@@ -1,11 +1,11 @@
 import json
 from typing import Any
 
+import docker
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 from pyjson5 import Json5DecoderException
 
-import docker
 from src.providers.constants import DOCKER_IMAGES, REGISTRY_PLUGINS_URL
 from src.providers.utils import load_json
 

--- a/src/providers/docker_test/__init__.py
+++ b/src/providers/docker_test/__init__.py
@@ -1,11 +1,11 @@
 import json
 from typing import Any
 
-import docker
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_core import PydanticCustomError
 from pyjson5 import Json5DecoderException
 
+import docker
 from src.providers.constants import DOCKER_IMAGES, REGISTRY_PLUGINS_URL
 from src.providers.utils import load_json
 
@@ -15,7 +15,7 @@ class Metadata(BaseModel):
 
     name: str
     desc: str
-    homepage: str
+    homepage: str | None = None
     type: str | None = None
     supported_adapters: list[str] | None = None
 

--- a/tests/utils/docker_test/test_docker_plugin_test.py
+++ b/tests/utils/docker_test/test_docker_plugin_test.py
@@ -52,3 +52,67 @@ async def test_docker_plugin_test(mocked_api: MockRouter, mocker: MockerFixture)
         detach=False,
         remove=True,
     )
+
+
+async def test_docker_plugin_test_metadata_some_fields_empty(
+    mocked_api: MockRouter, mocker: MockerFixture
+):
+    """测试 metadata 的部分字段为空"""
+    from src.providers.docker_test import DockerPluginTest, DockerTestResult, Metadata
+
+    mocked_run = mocker.Mock()
+    mocked_run.return_value = json.dumps(
+        {
+            "metadata": {
+                "name": "name",
+                "desc": "desc",
+                "homepage": None,
+                "type": None,
+                "supported_adapters": None,
+            },
+            "outputs": ["test"],
+            "load": True,
+            "run": True,
+            "version": "0.0.1",
+            "config": "",
+        }
+    ).encode()
+    mocked_client = mocker.Mock()
+    mocked_client.containers.run = mocked_run
+    mocked_docker = mocker.patch("docker.DockerClient")
+    mocked_docker.return_value = mocked_client
+
+    test = DockerPluginTest("project_link", "module_name")
+    result = await test.run("3.12")
+
+    assert result == snapshot(
+        DockerTestResult(
+            config="",
+            load=True,
+            metadata=Metadata(
+                desc="desc",
+                homepage=None,
+                name="name",
+                supported_adapters=None,
+                type=None,
+            ),
+            outputs=["test"],
+            run=True,
+            test_env="python==3.12",
+            version="0.0.1",
+        )
+    )
+
+    assert not mocked_api["store_plugins"].called
+    mocked_run.assert_called_once_with(
+        "ghcr.io/nonebot/nonetest:3.12-latest",
+        environment=snapshot(
+            {
+                "PLUGIN_INFO": "project_link:module_name",
+                "PLUGIN_CONFIG": "",
+                "PLUGINS_URL": "https://raw.githubusercontent.com/nonebot/registry/results/plugins.json",
+            }
+        ),
+        detach=False,
+        remove=True,
+    )


### PR DESCRIPTION
NoneBot 中是允许 homepage 为空的。

```python
@dataclass(eq=False)
class PluginMetadata:
    """插件元信息，由插件编写者提供"""

    name: str
    """插件名称"""
    description: str
    """插件功能介绍"""
    usage: str
    """插件使用方法"""
    type: Optional[str] = None
    """插件类型，用于商店分类"""
    homepage: Optional[str] = None
    """插件主页"""
    config: Optional[Type[BaseModel]] = None  # noqa: UP006
    """插件配置项"""
    supported_adapters: Optional[set[str]] = None
    """插件支持的适配器模块路径

    格式为 `<module>[:<Adapter>]`，`~` 为 `nonebot.adapters.` 的缩写。

    `None` 表示支持**所有适配器**。
    """
    extra: dict[Any, Any] = field(default_factory=dict)
    """插件额外信息，可由插件编写者自由扩展定义"""
```