### PR TITLE
fix(docker_test): 修复插件测试无法安装部分依赖的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复插件元数据异常时导致插件测试验证报错的问题
+- 修复插件测试无法安装部分依赖的问题
 
 ## [4.0.7] - 2024-11-20
 

--- a/src/providers/docker_test/Dockerfile
+++ b/src/providers/docker_test/Dockerfile
@@ -1,23 +1,21 @@
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.12
 
-FROM python:${PYTHON_VERSION} AS builder
-
-RUN apt-get update -y \
-    && apt-get install -y curl \
-    && rm -rf /var/lib/apt/lists/* 
-
-RUN curl -sSL https://install.python-poetry.org -o install-poetry.py 
-
-FROM python:${PYTHON_VERSION}-slim
+FROM python:${PYTHON_VERSION}
 
 WORKDIR /tmp
 
-COPY ./plugin_test.py /tmp/plugin_test.py
+# OpenCV 所需的依赖
+RUN apt-get update \
+  && apt-get -y upgrade \
+  && apt-get install ffmpeg libsm6 libxext6 -y \
+  && apt-get purge -y --auto-remove \
+  && rm -rf /var/lib/apt/lists/*
 
-COPY --from=builder install-poetry.py /tmp/install-poetry.py
-
-RUN python install-poetry.py --yes
+# 测试插件依赖 Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV PATH="${PATH}:/root/.local/bin"
+
+COPY ./plugin_test.py /tmp/plugin_test.py
 
 CMD ["python", "plugin_test.py"]


### PR DESCRIPTION
现在能正确安装 opencv-python 和 pillow。

<https://stackoverflow.com/questions/55313610/importerror-libgl-so-1-cannot-open-shared-object-file-no-such-file-or-directo>