### PR TITLE
fix(plugin_test): 修复插件元数据不合法时 metadata.json 为空的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复插件元数据不合法时 metadata.json 为空的问题
+
 ## [4.0.8] - 2024-11-20
 
 ### Fixed

--- a/src/providers/docker_test/plugin_test.py
+++ b/src/providers/docker_test/plugin_test.py
@@ -128,7 +128,10 @@ else:
             "supported_adapters": plugin.metadata.supported_adapters,
         }}
         with open("metadata.json", "w", encoding="utf-8") as f:
-            f.write(f"{{json.dumps(metadata, cls=SetEncoder)}}")
+            try:
+                f.write(f"{{json.dumps(metadata, cls=SetEncoder)}}")
+            except Exception:
+                f.write("{{}}")
 
         if plugin.metadata.config and not issubclass(plugin.metadata.config, BaseModel):
             logger.error("插件配置项不是 Pydantic BaseModel 的子类")


### PR DESCRIPTION
暂时通过捕获异常来处理，以后还需要重构 plugin_test 脚本。

<https://github.com/glamorgan9826/nonebot-plugin-today-waifu/blob/9a527c4dd28678cb53d23e601668b2b421bf076c/nonebot_plugin_today_waifu/__init__.py#L47>