### PR TITLE
fix(plugin_test): 超时后仍需读取 stdout 与 stderr 的内容

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - 从插件测试中提取环境信息
 
+### Fixed
+
+- 超时后仍需读取 stdout 与 stderr 的内容
+
 ## [4.0.11] - 2024-11-23
 
 ### Fixed

--- a/src/providers/docker_test/plugin_test.py
+++ b/src/providers/docker_test/plugin_test.py
@@ -334,7 +334,13 @@ class PluginTest:
             code = proc.returncode
         except TimeoutError:
             proc.terminate()
-            stdout, stderr = b"", "执行命令超时".encode()
+            # 超时后仍需读取 stdout 与 stderr 的内容
+            stdout = await proc.stdout.read() if proc.stdout else b""
+            stderr = (
+                "执行命令超时".encode() + await proc.stderr.read()
+                if proc.stderr
+                else "执行命令超时".encode()
+            )
             code = 1
 
         return not code, stdout.decode(), stderr.decode()


### PR DESCRIPTION
不然遇到这种测试超时的插件 <https://registry.nonebot.dev/plugin/nonebot-plugin-todo-nlp:nonebot_plugin_todo_nlp> 也不知道发生了什么。