### PR TITLE
fix: 修复插件测试结果中插件元数据 description 字段名称不正确的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 - 超时后仍需读取 stdout 与 stderr 的内容
 - 修复 Docker Test 报错未捕获的问题
+- 修复插件测试结果中插件元数据 description 字段名称不正确的问题
 
 ## [4.0.11] - 2024-11-23
 

--- a/src/providers/models.py
+++ b/src/providers/models.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import Any, Literal, Self, TypeAlias
 from zoneinfo import ZoneInfo
 
-from pydantic import BaseModel, Field, field_serializer
+from pydantic import BaseModel, Field, field_serializer, field_validator
 from pydantic_extra_types.color import Color
 
 from src.providers.constants import BOT_KEY_TEMPLATE, PYPI_KEY_TEMPLATE
@@ -356,6 +356,22 @@ class StoreTestResult(BaseModel):
                 ),
             },
         )
+
+    @field_validator("outputs", mode="before")
+    @classmethod
+    def outputs_metadata_validator(cls, v: dict[str, Any]) -> dict[str, Any]:
+        # nonebot2 中插件元数据的字段和商店中的字段不一致
+        if v["metadata"] is not None:
+            metadata = {}
+            # 将 metadata 中 desc 字段重命名为 description
+            # 同时保证其他字段顺序不变
+            for key, value in v["metadata"].items():
+                if key == "desc":
+                    metadata["description"] = value
+                else:
+                    metadata[key] = value
+            v["metadata"] = metadata
+        return v
 
 
 class RegistryUpdatePayload(BaseModel):

--- a/tests/github/config/process/test_config_check.py
+++ b/tests/github/config/process/test_config_check.py
@@ -258,7 +258,7 @@ async def test_process_config_check(
                         "load": "",
                         "metadata": {
                             "name": "name",
-                            "desc": "desc",
+                            "description": "desc",
                             "homepage": "https://nonebot.dev",
                             "type": "application",
                             "supported_adapters": ["nonebot.adapters.onebot.v11"],

--- a/tests/github/config/utils/test_config_update_file.py
+++ b/tests/github/config/utils/test_config_update_file.py
@@ -97,7 +97,7 @@ async def test_update_file(
                         "load": "test_output",
                         "metadata": {
                             "name": "帮助",
-                            "desc": "获取插件帮助信息",
+                            "description": "获取插件帮助信息",
                             "homepage": "https://github.com/he0119/nonebot-plugin-treehelp",
                             "type": "application",
                             "supported_adapters": None,

--- a/tests/github/publish/process/test_publish_pull_request.py
+++ b/tests/github/publish/process/test_publish_pull_request.py
@@ -117,7 +117,7 @@ async def test_process_pull_request(
                                 "load": "",
                                 "metadata": {
                                     "name": "name",
-                                    "desc": "desc",
+                                    "description": "desc",
                                     "homepage": "https://nonebot.dev",
                                     "type": "application",
                                     "supported_adapters": [
@@ -314,7 +314,7 @@ async def test_process_pull_request_skip_plugin_test(
                                 "load": "插件未进行测试",
                                 "metadata": {
                                     "name": "name",
-                                    "desc": "desc",
+                                    "description": "desc",
                                     "homepage": "https://nonebot.dev",
                                     "type": "application",
                                     "supported_adapters": [

--- a/tests/github/publish/utils/test_trigger_registry_update.py
+++ b/tests/github/publish/utils/test_trigger_registry_update.py
@@ -97,7 +97,7 @@ async def test_trigger_registry_update(
                                 "load": "",
                                 "metadata": {
                                     "name": "name",
-                                    "desc": "desc",
+                                    "description": "desc",
                                     "homepage": "https://nonebot.dev",
                                     "type": "application",
                                     "supported_adapters": [
@@ -195,7 +195,7 @@ async def test_trigger_registry_update_skip_test(
                                 "load": "插件未进行测试",
                                 "metadata": {
                                     "name": "name",
-                                    "desc": "desc",
+                                    "description": "desc",
                                     "homepage": "https://nonebot.dev",
                                     "type": "application",
                                     "supported_adapters": [


### PR DESCRIPTION
仅需要修改 StoreTestResult 中的数据。

为了方便验证，之前 #283 中直接将获取到的 metadata 中字段改名为 desc 了。

现在与 <https://github.com/nonebot/registry/blob/ac63c4e1d240004211e94b239bc016df18e89033/src/types/results.ts#L23-L30> 保持一致。