### PR TITLE
fix(plugin_test): 修复插件测试日志不全时版本号匹配失败的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Fixed
 
 - 修复 Docker Test 报错后仍无法运行的问题
+- 修复插件测试日志不全时版本号匹配失败的问题
 
 ## [4.1.0] - 2024-11-28
 

--- a/src/providers/docker_test/plugin_test.py
+++ b/src/providers/docker_test/plugin_test.py
@@ -203,6 +203,10 @@ def extract_version(output: str, project_link: str) -> str | None:
     if match:
         return match.group(1).strip()
 
+    match = re.search(rf"- Installing {project_link} \((\S+)\)", output)
+    if match:
+        return match.group(1).strip()
+
 
 def parse_requirements(requirements: str) -> dict[str, str]:
     """解析 requirements.txt 文件"""
@@ -326,12 +330,9 @@ class PluginTest:
         except TimeoutError:
             proc.terminate()
             # 超时后仍需读取 stdout 与 stderr 的内容
-            stdout = await proc.stdout.read() if proc.stdout else b""
-            stderr = (
-                "执行命令超时".encode() + await proc.stderr.read()
-                if proc.stderr
-                else "执行命令超时".encode()
-            )
+            stdout = "执行命令超时\n".encode()
+            stdout += await proc.stdout.read() if proc.stdout else b""
+            stderr = await proc.stderr.read() if proc.stderr else b""
             code = 1
 
         return not code, stdout.decode(), stderr.decode()

--- a/tests/utils/docker_test/test_extract_version.py
+++ b/tests/utils/docker_test/test_extract_version.py
@@ -113,3 +113,27 @@ def test_extract_version_install_failed(tmp_path: Path):
     version = extract_version(output, "nonebot2")
 
     assert version is None
+
+
+def test_extract_version_install_failed_partial_output(tmp_path: Path):
+    """安装插件失败的情况，输出不知道为什么只剩下了部分
+
+    TODO: 弄清楚为什么输出不完整。
+    """
+    from src.providers.docker_test.plugin_test import extract_version
+
+    output = """
+项目 nonebot-plugin-todo-nlp 创建失败：
+    执行命令超时
+    - Installing nonebot-plugin-todo-nlp (0.1.9)
+
+    Writing lock file
+"""
+
+    version = extract_version(output, "nonebot-plugin-todo-nlp")
+
+    assert version == "0.1.9"
+
+    version = extract_version(output, "nonebot2")
+
+    assert version is None


### PR DESCRIPTION
遇到了一个奇怪的输出，缺少了最前面的版本信息。

```log
项目 nonebot-plugin-todo-nlp 创建失败：
    - Installing nonebot-plugin-todo-nlp (0.1.9)
    
    Writing lock file
    执行命令超时Warning: Validation of the RECORD file of playwright-1.49.0-py3-none-manylinux1_x86_64.whl failed. Please report to the maintainers of that package so they can fix their build process. Details:
    In /root/.cache/pypoetry/artifacts/61/92/84/cc2c725417ce7948df6ef0ea8ee84b79dc02f0192924e28bc146c4d55e/playwright-1.49.0-py3-none-manylinux1_x86_64.whl, playwright/driver/LICENSE is not mentioned in RECORD
    In /root/.cache/pypoetry/artifacts/61/92/84/cc2c725417ce7948df6ef0ea8ee84b79dc02f0192924e28bc146c4d55e/playwright-1.49.0-py3-none-manylinux1_x86_64.whl, playwright/driver/node is not mentioned in RECORD
```

这是正常的输出：

```log
项目 nonebot-plugin-nailongremove 创建失败：
    Virtualenv
    Python:         3.12.7
    Implementation: CPython
    Path:           NA
    Executable:     NA
    
    Base
    Platform:   linux
    OS:         posix
    Python:     3.12.7
    Path:       /usr/local
    Executable: /usr/local/bin/python3.12
    Using version ^2.3.3.post1 for nonebot-plugin-nailongremove
    
    Updating dependencies
    Resolving dependencies...
    
    Package operations: 96 installs, 0 updates, 0 removals
    
      - Installing nvidia-nvjitlink-cu12 (12.4.127)
```