### PR TITLE
chore(deps): 移除 optional-dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Sync dependencies
-        run: uv sync --all-extras
-
       - name: Run tests
         run: uv run poe test
 

--- a/examples/store-test.yml
+++ b/examples/store-test.yml
@@ -45,12 +45,11 @@ jobs:
 
       - name: Test plugin
         if: ${{ !contains(fromJSON('["Bot", "Adapter", "Plugin"]'), github.event.client_payload.type) }}
-        run: |
-          uv run --no-dev --extra plugin python -m src.providers.store_test plugin-test --offset ${{ github.event.inputs.offset || 0 }} --limit ${{ github.event.inputs.limit || 50 }} ${{ github.event.inputs.args }}
+        run: uv run --no-dev -m src.providers.store_test plugin-test --offset ${{ github.event.inputs.offset || 0 }} --limit ${{ github.event.inputs.limit || 50 }} ${{ github.event.inputs.args }}
 
       - name: Update registry
         if: ${{ contains(fromJSON('["Bot", "Adapter", "Plugin"]'), github.event.client_payload.type) }}
-        run: uv run --no-dev --extra plugin python -m src.providers.store_test registry-update
+        run: uv run --no-dev -m src.providers.store_test registry-update
         env:
           REGISTRY_UPDATE_PAYLOAD: ${{ toJson(github.event.client_payload) }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">= 3.12"
 dependencies = [
+  "click>=8.1.7",
   "docker>=7.1.0",
   "githubkit>=0.11.14",
   "jinja2>=3.1.4",
@@ -15,6 +16,7 @@ dependencies = [
   "pre-commit>=4.0.1",
   "pydantic-extra-types>=2.10.0",
   "pyjson5>=1.6.7",
+  "tzdata>=2024.2",
 ]
 
 [project.urls]
@@ -22,9 +24,6 @@ Homepage = "https://github.com/nonebot/noneflow"
 Repository = "https://github.com/nonebot/noneflow.git"
 Issues = "https://github.com/nonebot/noneflow/issues"
 Changelog = "https://github.com/nonebot/noneflow/blob/main/CHANGELOG.md"
-
-[project.optional-dependencies]
-plugin = ["click>=8.1.7", "tzdata>=2024.2"]
 
 [tool.uv]
 dev-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -657,6 +657,7 @@ name = "noneflow"
 version = "4.1.2"
 source = { virtual = "." }
 dependencies = [
+    { name = "click" },
     { name = "docker" },
     { name = "githubkit" },
     { name = "jinja2" },
@@ -665,11 +666,6 @@ dependencies = [
     { name = "pre-commit" },
     { name = "pydantic-extra-types" },
     { name = "pyjson5" },
-]
-
-[package.optional-dependencies]
-plugin = [
-    { name = "click" },
     { name = "tzdata" },
 ]
 
@@ -688,7 +684,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", marker = "extra == 'plugin'", specifier = ">=8.1.7" },
+    { name = "click", specifier = ">=8.1.7" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "githubkit", specifier = ">=0.11.14" },
     { name = "jinja2", specifier = ">=3.1.4" },
@@ -697,7 +693,7 @@ requires-dist = [
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pydantic-extra-types", specifier = ">=2.10.0" },
     { name = "pyjson5", specifier = ">=1.6.7" },
-    { name = "tzdata", marker = "extra == 'plugin'", specifier = ">=2024.2" },
+    { name = "tzdata", specifier = ">=2024.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
这样可以避免本地开发时因为忘记使用 uv sync --all-extras 命令导致测试出错。

以前是为了降低 noneflow docker 镜像的大小，现在已经弃疗了。