### PR TITLE
fix: 统一数据显示顺序并且时间添加时区

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 统一数据显示顺序并且时间添加时区
+
 ## [4.2.0] - 2024-12-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ select = [
   "PT",    # flake8-pytest-style
   "Q",     # flake8-quotes
   "TC",    # flake8-type-checking
+  "DTZ",   # flake8-datetimez
   "RUF",   # Ruff-specific rules
   "I",     # isort
 ]

--- a/src/plugins/github/plugins/publish/render.py
+++ b/src/plugins/github/plugins/publish/render.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import jinja2
 
 from src.plugins.github import plugin_config
+from src.providers.constants import TIME_ZONE
 from src.providers.docker_test import DockerTestResult
 from src.providers.utils import dumps_json
 from src.providers.validation import ValidationDict
@@ -47,7 +47,7 @@ def format_time(time: str) -> str:
     """格式化时间"""
     dt = datetime.fromisoformat(time)
     # 转换为中国时区，方便阅读
-    dt = dt.astimezone(tz=ZoneInfo("Asia/Shanghai"))
+    dt = dt.astimezone(tz=TIME_ZONE)
     return dt.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 

--- a/src/plugins/github/plugins/publish/render.py
+++ b/src/plugins/github/plugins/publish/render.py
@@ -46,7 +46,6 @@ def key_to_name(key: str) -> str:
 def format_time(time: str) -> str:
     """格式化时间"""
     dt = datetime.fromisoformat(time)
-    # 转换为中国时区，方便阅读
     dt = dt.astimezone(tz=TIME_ZONE)
     return dt.strftime("%Y-%m-%d %H:%M:%S %Z")
 

--- a/src/plugins/github/plugins/publish/render.py
+++ b/src/plugins/github/plugins/publish/render.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 import jinja2
 
@@ -70,9 +69,6 @@ async def render_comment(result: ValidationDict, reuse: bool = False) -> str:
     """将验证结果转换为评论内容"""
     title = f"{result.type}: {result.name}"
 
-    # 将 data 字段拷贝一份，避免修改原数据
-    valid_data: dict[str, Any] = result.valid_data.copy()
-
     # 仅显示必要字段
     display_keys = [
         "homepage",
@@ -85,7 +81,9 @@ async def render_comment(result: ValidationDict, reuse: bool = False) -> str:
     ]
 
     # 按照 display_keys 顺序展示数据
-    data = {key: valid_data[key] for key in display_keys if key in valid_data}
+    data = {
+        key: result.valid_data[key] for key in display_keys if key in result.valid_data
+    }
 
     if not data.get("tags"):
         data.pop("tags", None)

--- a/src/providers/constants.py
+++ b/src/providers/constants.py
@@ -1,4 +1,8 @@
 import os
+from zoneinfo import ZoneInfo
+
+TIME_ZONE = ZoneInfo("Asia/Shanghai")
+""" NoneFlow 统一的时区 """
 
 BOT_KEY_TEMPLATE = "{name}:{homepage}"
 """ 机器人键名模板 """

--- a/src/providers/models.py
+++ b/src/providers/models.py
@@ -1,12 +1,11 @@
 # ruff: noqa: UP040
 from datetime import datetime
 from typing import Any, Literal, Self, TypeAlias
-from zoneinfo import ZoneInfo
 
 from pydantic import BaseModel, Field, field_serializer, field_validator
 from pydantic_extra_types.color import Color
 
-from src.providers.constants import BOT_KEY_TEMPLATE, PYPI_KEY_TEMPLATE
+from src.providers.constants import BOT_KEY_TEMPLATE, PYPI_KEY_TEMPLATE, TIME_ZONE
 from src.providers.docker_test import Metadata
 from src.providers.utils import get_author_name, get_pypi_upload_time, get_pypi_version
 from src.providers.validation import validate_info
@@ -412,9 +411,7 @@ RegistryModels: TypeAlias = (
 
 
 class StoreTestResult(BaseModel):
-    time: str = Field(
-        default_factory=lambda: datetime.now(ZoneInfo("Asia/Shanghai")).isoformat()
-    )
+    time: str = Field(default_factory=lambda: datetime.now(TIME_ZONE).isoformat())
     """测试时间"""
     config: str = ""
     """测试插件的配置"""

--- a/src/providers/store_test/store.py
+++ b/src/providers/store_test/store.py
@@ -13,6 +13,7 @@ from src.providers.constants import (
     STORE_BOTS_URL,
     STORE_DRIVERS_URL,
     STORE_PLUGINS_URL,
+    TIME_ZONE,
 )
 from src.providers.logger import logger
 from src.providers.models import (
@@ -379,7 +380,7 @@ class StoreTest:
         ]
         summary = f"""# 📃 商店测试结果
 
-> 📅 {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+> 📅 {datetime.now(TIME_ZONE).strftime("%Y-%m-%d %H:%M:%S %Z")}
 > ♻️ 共测试 {len(results)} 个插件
 > ✅ 更新成功：{len(valid_plugins)} 个
 > ❌ 更新失败：{len(invalid_plugins)} 个

--- a/tests/plugins/github/config/process/test_config_check.py
+++ b/tests/plugins/github/config/process/test_config_check.py
@@ -148,7 +148,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2024-07-13 04:41:40。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: nonebot.adapters.onebot.v11。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: nonebot.adapters.onebot.v11。</li><li>✅ 插件发布时间：2024-07-13 12:41:40 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/config/process/test_config_check.py
+++ b/tests/plugins/github/config/process/test_config_check.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from inline_snapshot import snapshot
 from nonebot.adapters.github import IssuesOpened
@@ -32,6 +31,7 @@ async def test_process_config_check(
     mock_results: dict[str, Path],
 ) -> None:
     """测试发布检查不通过"""
+    from src.providers.constants import TIME_ZONE
     from src.providers.docker_test import Metadata
 
     # 更改当前工作目录为临时目录
@@ -39,7 +39,7 @@ async def test_process_config_check(
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     mock_subprocess_run = mocker.patch(

--- a/tests/plugins/github/config/utils/test_config_update_file.py
+++ b/tests/plugins/github/config/utils/test_config_update_file.py
@@ -1,7 +1,6 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from inline_snapshot import snapshot
 from nonebug import App
@@ -17,6 +16,7 @@ async def test_update_file(
     mock_results: dict[str, Path],
 ) -> None:
     from src.plugins.github.plugins.config.utils import update_file
+    from src.providers.constants import TIME_ZONE
     from src.providers.validation.models import (
         PluginPublishInfo,
         PublishType,
@@ -28,7 +28,7 @@ async def test_update_file(
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     raw_data = {

--- a/tests/plugins/github/publish/process/test_publish_check.py
+++ b/tests/plugins/github/publish/process/test_publish_check.py
@@ -281,7 +281,7 @@ async def test_adapter_process_publish_check(
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 00:00:00。</li><li>✅ 插件版本号: 0.0.1。</li><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 0.0.1。</li></code></pre>
 </details>
 
 ---
@@ -568,7 +568,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 00:00:00。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
 </details>
 
 ---
@@ -857,7 +857,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 00:00:00。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
 </details>
 
 ---
@@ -1754,7 +1754,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 00:00:00。</li><li>✅ 插件版本号: 0.0.1。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 已跳过。</li></code></pre>
+<pre><code><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 0.0.1。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 已跳过。</li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/publish/render/test_publish_render_data.py
+++ b/tests/plugins/github/publish/render/test_publish_render_data.py
@@ -134,7 +134,7 @@ async def test_render_data_adapter(app: App):
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 标签: 米哈游-#e10909。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 标签: 米哈游-#e10909。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li></code></pre>
 </details>
 
 ---
@@ -168,6 +168,8 @@ async def test_render_data_plugin(app: App, mocker: MockFixture):
         "supported_adapters": None,
         "load": True,
         "skip_test": False,
+        "time": "2024-07-13T04:41:40.905441Z",
+        "version": "0.5.0",
     }
     result = ValidationDict(
         type=PublishType.PLUGIN,
@@ -189,7 +191,7 @@ async def test_render_data_plugin(app: App, mocker: MockFixture):
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2024-07-13 12:41:40 CST。</li><li>✅ 插件版本号: 0.5.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
 </details>
 
 ---

--- a/tests/providers/store_test/test_step_summary.py
+++ b/tests/providers/store_test/test_step_summary.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from inline_snapshot import snapshot
 from pytest_mock import MockerFixture
@@ -11,12 +10,13 @@ async def test_step_summary(
     mocked_store_data: dict[str, Path], mocked_api: MockRouter, mocker: MockerFixture
 ) -> None:
     """验证插件信息"""
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import StoreTestResult
     from src.providers.store_test.store import StoreTest
 
     mock_datetime = mocker.patch("src.providers.store_test.store.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     store_test = {
@@ -66,7 +66,7 @@ async def test_step_summary(
         """\
 # 📃 商店测试结果
 
-> 📅 2023-08-23 09:22:14
+> 📅 2023-08-23 09:22:14 CST
 > ♻️ 共测试 2 个插件
 > ✅ 更新成功：1 个
 > ❌ 更新失败：1 个

--- a/tests/providers/store_test/test_validate_plugin.py
+++ b/tests/providers/store_test/test_validate_plugin.py
@@ -1,7 +1,6 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from zoneinfo import ZoneInfo
 
 from inline_snapshot import snapshot
 from pytest_mock import MockerFixture
@@ -26,12 +25,13 @@ def mock_docker_result(path: Path, mocker: MockerFixture):
 
 async def test_validate_plugin(mocked_api: MockRouter, mocker: MockerFixture) -> None:
     """验证插件信息"""
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import RegistryPlugin, StorePlugin, StoreTestResult
     from src.providers.store_test.validation import validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     output_path = Path(__file__).parent / "output.json"
@@ -103,12 +103,13 @@ async def test_validate_plugin_with_previous(
 
     需要能够正常更新 author_id, tags 和 is_official 等信息
     """
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import Color, RegistryPlugin, StoreTestResult, Tag
     from src.providers.store_test.validation import StorePlugin, validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     output_path = Path(__file__).parent / "output.json"
@@ -200,12 +201,13 @@ async def test_validate_plugin_skip_test(
 
     如果插件之前是跳过测试的，如果插件测试成功，应将 skip_test 设置为 False。
     """
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import RegistryPlugin, StoreTestResult
     from src.providers.store_test.validation import StorePlugin, validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     output_path = Path(__file__).parent / "output.json"
@@ -277,12 +279,13 @@ async def test_validate_plugin_skip_test_plugin_test_failed(
 
     如果插件之前是跳过测试的，如果插件测试失败，应不改变 skip_test 的值。
     """
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import RegistryPlugin, StoreTestResult
     from src.providers.store_test.validation import StorePlugin, validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     output_path = Path(__file__).parent / "output_failed.json"
@@ -362,12 +365,13 @@ async def test_validate_plugin_failed_with_previous(
 
     需要能够正常更新 author_id, tags 和 is_official 等信息
     """
+    from src.providers.constants import TIME_ZONE
     from src.providers.models import RegistryPlugin, StoreTestResult
     from src.providers.store_test.validation import StorePlugin, validate_plugin
 
     mock_datetime = mocker.patch("src.providers.models.datetime")
     mock_datetime.now.return_value = datetime(
-        2023, 8, 23, 9, 22, 14, 836035, tzinfo=ZoneInfo("Asia/Shanghai")
+        2023, 8, 23, 9, 22, 14, 836035, tzinfo=TIME_ZONE
     )
 
     output_path = Path(__file__).parent / "output_failed.json"


### PR DESCRIPTION
应该是这个效果，之前时间没带时区，都不知道具体是什么时间。

# 📃 商店发布检查结果

> Plugin: 帮助

**✅ 所有测试通过，一切准备就绪！**


<details>
<summary>详情</summary>
<pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2024-07-13 12:41:40 CST。</li><li>✅ 插件版本号: 0.5.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
</details>

---

💡 如需修改信息，请直接修改 issue，机器人会自动更新检查结果。
💡 当插件加载测试失败时，请发布新版本后勾选插件测试勾选框重新运行插件测试。


💪 Powered by [NoneFlow](https://github.com/nonebot/noneflow)
<!-- NONEFLOW -->