### PR TITLE
fix: 重新调整数据显示顺序和文本

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 重新调整数据显示顺序和文本
+
 ## [4.2.1] - 2024-12-20
 
 ### Fixed

--- a/src/plugins/github/plugins/publish/constants.py
+++ b/src/plugins/github/plugins/publish/constants.py
@@ -59,6 +59,6 @@ LOC_NAME_MAP = {
     "supported_adapters": "插件支持的适配器",
     "metadata": "插件测试元数据",
     "load": "插件是否成功加载",
-    "version": "插件版本号",
-    "time": "插件发布时间",
+    "version": "版本号",
+    "time": "发布时间",
 }

--- a/src/plugins/github/plugins/publish/templates/render_data.md.jinja
+++ b/src/plugins/github/plugins/publish/templates/render_data.md.jinja
@@ -16,7 +16,7 @@
 插件 <a href="{{ value }}">加载测试</a> 通过。
 {%- endif %}
 {%- elif key == "time" %}
-插件发布时间：{{ value|format_time }}。
+发布时间：{{ value|format_time }}。
 {%- else %}
 {{ key|key_to_name }}: {{ value }}。
 {%- endif %}

--- a/tests/plugins/github/config/process/test_config_check.py
+++ b/tests/plugins/github/config/process/test_config_check.py
@@ -148,7 +148,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: nonebot.adapters.onebot.v11。</li><li>✅ 插件发布时间：2024-07-13 12:41:40 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: nonebot.adapters.onebot.v11。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li><li>✅ 版本号: 1.0.0。</li><li>✅ 发布时间：2024-07-13 12:41:40 CST。</li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/publish/process/test_publish_check.py
+++ b/tests/plugins/github/publish/process/test_publish_check.py
@@ -281,7 +281,7 @@ async def test_adapter_process_publish_check(
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 0.0.1。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 版本号: 0.0.1。</li><li>✅ 发布时间：2023-09-01 08:00:00 CST。</li></code></pre>
 </details>
 
 ---
@@ -568,7 +568,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li><li>✅ 版本号: 1.0.0。</li><li>✅ 发布时间：2023-09-01 08:00:00 CST。</li></code></pre>
 </details>
 
 ---
@@ -857,7 +857,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 1.0.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li><li>✅ 版本号: 1.0.0。</li><li>✅ 发布时间：2023-09-01 08:00:00 CST。</li></code></pre>
 </details>
 
 ---
@@ -1754,7 +1754,7 @@ log_level=DEBUG
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 标签: test-#ffffff。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 插件发布时间：2023-09-01 08:00:00 CST。</li><li>✅ 插件版本号: 0.0.1。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 已跳过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 已跳过。</li><li>✅ 版本号: 0.0.1。</li><li>✅ 发布时间：2023-09-01 08:00:00 CST。</li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/publish/render/test_publish_render_data.py
+++ b/tests/plugins/github/publish/render/test_publish_render_data.py
@@ -113,6 +113,8 @@ async def test_render_data_adapter(app: App):
         "homepage": "https://github.com/CMHopeSunshine/nonebot-adapter-villa",
         "tags": [{"label": "米哈游", "color": "#e10909"}],
         "is_official": False,
+        "time": "2023-12-21T06:57:44.318894Z",
+        "version": "1.4.2",
     }
     result = ValidationDict(
         type=PublishType.ADAPTER,
@@ -134,7 +136,7 @@ async def test_render_data_adapter(app: App):
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 标签: 米哈游-#e10909。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li><li>✅ 标签: 米哈游-#e10909。</li><li>✅ 版本号: 1.4.2。</li><li>✅ 发布时间：2023-12-21 14:57:44 CST。</li></code></pre>
 </details>
 
 ---
@@ -162,7 +164,7 @@ async def test_render_data_plugin(app: App, mocker: MockFixture):
         "author": "he0119",
         "author_id": 1,
         "homepage": "https://github.com/he0119/nonebot-plugin-treehelp",
-        "tags": [],
+        "tags": [{"label": "render", "color": "#ffffff"}],
         "is_official": False,
         "type": "application",
         "supported_adapters": None,
@@ -191,7 +193,7 @@ async def test_render_data_plugin(app: App, mocker: MockFixture):
 
 <details>
 <summary>详情</summary>
-<pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件发布时间：2024-07-13 12:41:40 CST。</li><li>✅ 插件版本号: 0.5.0。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li></code></pre>
+<pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 标签: render-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li><li>✅ 版本号: 0.5.0。</li><li>✅ 发布时间：2024-07-13 12:41:40 CST。</li></code></pre>
 </details>
 
 ---


### PR DESCRIPTION
除了插件，适配器也会用到，所以应该删掉插件的前缀。#330 并没有修改好。

# 📃 商店发布检查结果

> Plugin: 帮助

**✅ 所有测试通过，一切准备就绪！**


<details>
<summary>详情</summary>
<pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-plugin-treehelp/">nonebot-plugin-treehelp</a> 已发布至 PyPI。</li><li>✅ 标签: render-#ffffff。</li><li>✅ 插件类型: application。</li><li>✅ 插件支持的适配器: 所有。</li><li>✅ 插件 <a href="https://github.com/owner/repo/actions/runs/123456">加载测试</a> 通过。</li><li>✅ 版本号: 0.5.0。</li><li>✅ 发布时间：2024-07-13 12:41:40 CST。</li></code></pre>
</details>

---

💡 如需修改信息，请直接修改 issue，机器人会自动更新检查结果。
💡 当插件加载测试失败时，请发布新版本后勾选插件测试勾选框重新运行插件测试。


💪 Powered by [NoneFlow](https://github.com/nonebot/noneflow)
<!-- NONEFLOW -->

# 📃 商店发布检查结果

> Adapter: 大别野

**✅ 所有测试通过，一切准备就绪！**


<details>
<summary>详情</summary>
<pre><code><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li><li>✅ 标签: 米哈游-#e10909。</li><li>✅ 版本号: 1.4.2。</li><li>✅ 发布时间：2023-12-21 14:57:44 CST。</li></code></pre>
</details>

---

💡 如需修改信息，请直接修改 issue，机器人会自动更新检查结果。
💡 当插件加载测试失败时，请发布新版本后勾选插件测试勾选框重新运行插件测试。


💪 Powered by [NoneFlow](https://github.com/nonebot/noneflow)
<!-- NONEFLOW -->