### PR TITLE
fix: 将拉取请求和相关议题放在同一个并发组

### DIFF
--- a/examples/noneflow.yml
+++ b/examples/noneflow.yml
@@ -12,7 +12,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number && format('publish/issue{0}', github.event.issue.number) || github.head_ref || github.run_id }}
-  cancel-in-progress: ${{ contains(github.head_ref, 'publish/issue')}}
+  cancel-in-progress: ${{ startsWith(github.head_ref, 'publish/issue')}}
 
 jobs:
   noneflow:

--- a/examples/noneflow.yml
+++ b/examples/noneflow.yml
@@ -11,8 +11,8 @@ on:
     types: [submitted]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.issue.number && format('publish/issue{0}', github.event.issue.number) || github.head_ref || github.run_id }}
+  cancel-in-progress: ${{ contains(github.head_ref, 'publish/issue')}}
 
 jobs:
   noneflow:

--- a/examples/noneflow.yml
+++ b/examples/noneflow.yml
@@ -3,10 +3,10 @@ name: NoneFlow
 on:
   issues:
     types: [opened, reopened, edited]
-  pull_request_target:
-    types: [closed]
   issue_comment:
     types: [created]
+  pull_request_target:
+    types: [closed]
   pull_request_review:
     types: [submitted]
 


### PR DESCRIPTION
并且是拉取请求相关操作时，会取消之前正在运行的操作。

比如，当评论之后马上关闭拉取请求，这个时候评论触发的操作还在进行，拉取请求的操作又被触发时，之前评论的操作会因为是同一个并发组被取消。

如果此时拉取请求的操作还在排队，这时候分支还存在，因为之前将拉取请求和分支绑定，也不会新建拉取请求。待拉取请求触发的操作运行后，会自动删除相关分支。

fixed #345