### PR TITLE
fix: 修复插件元数据适配器中存在非字符串报错的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复插件元数据适配器中存在非字符串报错的问题
+
 ## [4.3.0] - 2025-04-18
 
 ### Added

--- a/src/providers/validation/models.py
+++ b/src/providers/validation/models.py
@@ -278,6 +278,9 @@ class PluginPublishInfo(PublishInfo, PyPIMixin):
         if not isinstance(v, list | set):
             raise PydanticCustomError("set_type", "值应该是一个集合")
 
+        if any(not isinstance(x, str) for x in v):
+            raise PydanticCustomError("set_type", "集合中的值应该是字符串")
+
         supported_adapters = {resolve_adapter_name(x) for x in v}
         store_adapters = get_adapters()
 

--- a/src/providers/validation/models.py
+++ b/src/providers/validation/models.py
@@ -278,7 +278,7 @@ class PluginPublishInfo(PublishInfo, PyPIMixin):
         if not isinstance(v, list | set):
             raise PydanticCustomError("set_type", "值应该是一个集合")
 
-        if any(not isinstance(x, str) for x in v):
+        if not all(isinstance(x, str) for x in v):
             raise PydanticCustomError("set_type", "集合中的值应该是字符串")
 
         supported_adapters = {resolve_adapter_name(x) for x in v}

--- a/tests/providers/validation/fields/test_plugin_supported_adapters.py
+++ b/tests/providers/validation/fields/test_plugin_supported_adapters.py
@@ -199,3 +199,47 @@ async def test_plugin_supported_adapters_missing_adapters(
     )
 
     assert mocked_api["homepage"].called
+
+
+async def test_plugin_supported_adapters_not_all_str(mocked_api: MockRouter) -> None:
+    """列表中有非字符串的情况"""
+    from src.providers.validation import PublishType, validate_info
+
+    data = generate_plugin_data(supported_adapters={None, "~qq"}, skip_test=True)
+
+    result = validate_info(PublishType.PLUGIN, data, [])
+
+    assert not result.valid
+    assert result.type == PublishType.PLUGIN
+    assert result.valid_data == snapshot(
+        {
+            "module_name": "module_name",
+            "project_link": "project_link",
+            "time": "2023-09-01T00:00:00.000000Z",
+            "name": "name",
+            "desc": "desc",
+            "author": "author",
+            "author_id": 1,
+            "homepage": "https://nonebot.dev",
+            "tags": [{"label": "test", "color": "#ffffff"}],
+            "type": "application",
+            "load": True,
+            "metadata": True,
+            "skip_test": True,
+            "version": "0.0.1",
+            "test_output": "test_output",
+        }
+    )
+    assert result.info is None
+    assert result.errors == snapshot(
+        [
+            {
+                "type": "set_type",
+                "loc": ("supported_adapters",),
+                "msg": "值不是合法的集合",
+                "input": {"~qq", None},
+            }
+        ]
+    )
+
+    assert mocked_api["homepage"].called


### PR DESCRIPTION
唉，用户输入。

https://github.com/nonebot/nonebot2/issues/3456

https://github.com/bananaxiao2333/nonebot-plugin-uptime-kuma-puller/blob/cd07468e6ff6f48a7ecd9bc8a442889d36dc1a11/nonebot_plugin_uptime_kuma_puller/__init__.py#L30