### PR TITLE
fix: 修复机器人/适配器发布时没有历史测试的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复机器人/适配器发布时没有历史测试的问题
+
 ## [4.4.0] - 2025-06-17
 
 ### Added

--- a/tests/plugins/github/publish/process/test_publish_check.py
+++ b/tests/plugins/github/publish/process/test_publish_check.py
@@ -100,6 +100,10 @@ async def test_bot_process_publish_check(
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
 </details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -258,6 +262,10 @@ async def test_adapter_process_publish_check(
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/project_link/">project_link</a> 已发布至 PyPI。</li><li>✅ 标签: test-#ffffff。</li><li>✅ 版本号: 0.0.1。</li><li>✅ 发布时间：2023-09-01 08:00:00 CST。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -436,6 +444,10 @@ async def test_edit_title(
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -627,6 +639,10 @@ async def test_edit_title_too_long(
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
 </details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -756,6 +772,10 @@ async def test_process_publish_check_not_pass(
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 标签: test-#ffffff。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -984,6 +1004,10 @@ async def test_convert_pull_request_to_draft(
 <summary>详情</summary>
 <pre><code><li>✅ 标签: test-#ffffff。</li></code></pre>
 </details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -1116,6 +1140,10 @@ async def test_process_publish_check_ready_for_review(
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -1301,6 +1329,10 @@ async def test_comment_immediate_after_pull_request_closed(
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://nonebot.dev">主页</a> 返回状态码 200。</li><li>✅ 标签: test-#ffffff。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/publish/render/test_publish_render.py
+++ b/tests/plugins/github/publish/render/test_publish_render.py
@@ -27,6 +27,10 @@ async def test_render_empty(app: App):
 **✅ 所有测试通过，一切准备就绪！**
 
 
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -61,6 +65,10 @@ async def test_render_reuse(app: App):
 **✅ 所有测试通过，一切准备就绪！**
 
 
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 

--- a/tests/plugins/github/publish/render/test_publish_render_data.py
+++ b/tests/plugins/github/publish/render/test_publish_render_data.py
@@ -43,6 +43,10 @@ async def test_render_data_bot(app: App):
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://github.com/he0119/CoolQBot">主页</a> 返回状态码 200。</li></code></pre>
 </details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -90,6 +94,10 @@ async def test_render_data_bot(app: App):
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://github.com/Mar-7th/March7th">主页</a> 返回状态码 200。</li><li>✅ 标签: StarRail-#5a8ccc, 星穹铁道-#6faec6。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -145,6 +153,10 @@ async def test_render_data_adapter(app: App):
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://github.com/CMHopeSunshine/nonebot-adapter-villa">主页</a> 返回状态码 200。</li><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li><li>✅ 标签: 米哈游-#e10909。</li><li>✅ 版本号: 1.4.2。</li><li>✅ 发布时间：2023-12-21 14:57:44 CST。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>✅ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---

--- a/tests/plugins/github/publish/render/test_publish_render_error.py
+++ b/tests/plugins/github/publish/render/test_publish_render_error.py
@@ -58,6 +58,10 @@ async def test_render_error_bot(app: App):
 
 <pre><code><li>⚠️ 名称: 字符过多。<dt>请确保其不超过 50 个字符。</dt></li><li>⚠️ 项目 <a href="https://www.baidu.com">主页</a> 返回状态码 404。<dt>请确保你的项目主页可访问。</dt></li><li>⚠️ 第 2 个标签名称过长。<dt>请确保标签名称不超过 10 个字符。</dt></li><li>⚠️ 第 2 个标签颜色错误。<dt>请确保标签颜色符合十六进制颜色码规则。</dt></li></code></pre>
 
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
+</details>
 
 ---
 
@@ -144,6 +148,10 @@ async def test_render_error_adapter(app: App):
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://pypi.org/project/nonebot-adapter-villa/">nonebot-adapter-villa</a> 已发布至 PyPI。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---
@@ -313,6 +321,10 @@ async def test_render_error_plugin_load_test(app: App):
 <details>
 <summary>详情</summary>
 <pre><code><li>✅ 项目 <a href="https://github.com/he0119/nonebot-plugin-treehelp">主页</a> 返回状态码 200。</li></code></pre>
+</details>
+<details>
+<summary>历史测试</summary>
+<pre><code><li>⚠️ <a href=https://github.com/owner/repo/actions/runs/123456>2023-08-23 09:22:14 CST</a></li></code></pre>
 </details>
 
 ---


### PR DESCRIPTION
任何时候都应该显示历史测试，因为 #394 和 #401 依赖其提供数据。