### PR TITLE
docs: 用 pull_request 替代 pull_request_target

### DIFF
--- a/examples/noneflow-registry.yml
+++ b/examples/noneflow-registry.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited]
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [closed]
 
 concurrency:

--- a/examples/noneflow-results.yml
+++ b/examples/noneflow-results.yml
@@ -1,7 +1,7 @@
 name: NoneFlow
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
   pull_request_review:
     types: [submitted]

--- a/examples/noneflow.yml
+++ b/examples/noneflow.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited]
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [closed]
   pull_request_review:
     types: [submitted]


### PR DESCRIPTION
所有的 PR 应该都是 noneflow 自己在当前仓库创建并且自己合并的，所以不需要 pull_request_target