### PR TITLE
fix(store-test): 清理同步时遗留的旧商店数据

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ uv run poe bump
 3. **并发控制**: 使用 `concurrency` 配置避免同一议题的并发处理
 4. **Artifact 传递**: 通过 GitHub Actions Artifact 在不同工作流间传递数据
 5. **变更记录**: 修复缺陷、调整用户可见行为或发布流程时，同步更新 `CHANGELOG.md` 的 `[Unreleased]` 条目
+6. **分支命名**: 新建分支应匹配 `.github/release-drafter.yml` 的自动标签规则，修复使用 `fix/...`，新功能使用 `feat/...` 或 `feature/...`，行为变更使用 `change/...`，改进使用 `improve/...`
 
 ## 相关仓库
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ uv run poe bump
 2. **Docker 测试**: 插件测试需要 Docker 环境，测试时会拉取插件代码并在隔离环境中运行
 3. **并发控制**: 使用 `concurrency` 配置避免同一议题的并发处理
 4. **Artifact 传递**: 通过 GitHub Actions Artifact 在不同工作流间传递数据
+5. **变更记录**: 修复缺陷、调整用户可见行为或发布流程时，同步更新 `CHANGELOG.md` 的 `[Unreleased]` 条目
 
 ## 相关仓库
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复商店同步时不会清理 registry 中已移除插件、适配器、驱动器和机器人的问题
+
 ## [4.5.0] - 2026-04-01
 
 ### Added

--- a/src/providers/store_test/store.py
+++ b/src/providers/store_test/store.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from src.providers.constants import (
     BOT_KEY_TEMPLATE,
@@ -48,6 +49,9 @@ from .validation import validate_plugin
 
 if TYPE_CHECKING:
     from src.providers.models import RegistryArtifactData
+
+StoreModelT = TypeVar("StoreModelT")
+RegistryModelT = TypeVar("RegistryModelT")
 
 
 class StoreTest:
@@ -353,61 +357,86 @@ class StoreTest:
 
         self.dump_data()
 
+    @staticmethod
+    def _sync_registry_data(
+        previous_data: dict[str, RegistryModelT],
+        store_data: dict[str, StoreModelT],
+        data_type: str,
+        update_registry: Callable[[RegistryModelT, StoreModelT], RegistryModelT],
+        create_registry: Callable[[StoreModelT], RegistryModelT],
+    ) -> dict[str, RegistryModelT]:
+        """以 nonebot2 仓库商店数据为准同步 registry 数据。"""
+        synced_data: dict[str, RegistryModelT] = {}
+        # 只遍历当前 store 中存在的 key，未写入 synced_data 的旧 key 会被清理。
+        for key, store_item in store_data.items():
+            try:
+                if key in previous_data:
+                    synced_item = update_registry(previous_data[key], store_item)
+                else:
+                    synced_item = create_registry(store_item)
+            except Exception as e:
+                logger.error(f"{data_type} {key} 同步商店数据失败：{e}")
+                if key in previous_data:
+                    synced_data[key] = previous_data[key]
+                continue
+
+            synced_data[key] = synced_item
+
+        return synced_data
+
+    @staticmethod
+    def _create_plugin_registry(_: StorePlugin) -> RegistryPlugin:
+        # TODO: 如果插件不存在，尝试重新测试获取相关信息验证
+        raise NotImplementedError("插件需要重新测试")
+
     async def sync_store(self):
         """同步商店数据
 
         以商店数据为准，更新商店数据到仓库中，如果仓库中不存在则获取用户名后存储
         """
-        for key in self._store_adapters:
-            try:
-                if key in self._previous_adapters:
-                    new_adapter = self._previous_adapters[key].update(
-                        self._store_adapters[key]
-                    )
-                else:
-                    new_adapter = self._store_adapters[key].to_registry()
-            except Exception as e:
-                logger.error(f"适配器 {key} 同步商店数据失败：{e}")
-                continue
-            self._previous_adapters[key] = new_adapter
-        for key in self._store_bots:
-            try:
-                if key in self._previous_bots:
-                    new_bot = self._previous_bots[key].update(self._store_bots[key])
-                else:
-                    new_bot = self._store_bots[key].to_registry()
-            except Exception as e:
-                logger.error(f"机器人 {key} 同步商店数据失败：{e}")
-                continue
+        self._previous_adapters = self._sync_registry_data(
+            self._previous_adapters,
+            self._store_adapters,
+            "适配器",
+            RegistryAdapter.update,
+            StoreAdapter.to_registry,
+        )
+        self._previous_bots = self._sync_registry_data(
+            self._previous_bots,
+            self._store_bots,
+            "机器人",
+            RegistryBot.update,
+            StoreBot.to_registry,
+        )
+        self._previous_drivers = self._sync_registry_data(
+            self._previous_drivers,
+            self._store_drivers,
+            "驱动器",
+            RegistryDriver.update,
+            StoreDriver.to_registry,
+        )
+        self._previous_plugins = self._sync_registry_data(
+            self._previous_plugins,
+            self._store_plugins,
+            "插件",
+            RegistryPlugin.update,
+            self._create_plugin_registry,
+        )
 
-            self._previous_bots[key] = new_bot
-        for key in self._store_drivers:
-            try:
-                if key in self._previous_drivers:
-                    new_driver = self._previous_drivers[key].update(
-                        self._store_drivers[key]
-                    )
-                else:
-                    new_driver = self._store_drivers[key].to_registry()
-            except Exception as e:
-                logger.error(f"驱动器 {key} 同步商店数据失败：{e}")
-                continue
-
-            self._previous_drivers[key] = new_driver
-        for key in self._store_plugins:
-            try:
-                if key in self._previous_plugins:
-                    new_plugin = self._previous_plugins[key].update(
-                        self._store_plugins[key]
-                    )
-                else:
-                    # TODO: 如果插件不存在，尝试重新测试获取相关信息验证
-                    raise NotImplementedError("插件需要重新测试")
-            except Exception as e:
-                logger.error(f"插件 {key} 同步商店数据失败：{e}")
-                continue
-
-            self._previous_plugins[key] = new_plugin
+        store_plugin_keys = set(self._store_plugins)
+        # 插件被从 nonebot2 仓库移除后，registry results 中对应的测试结果
+        # 也要删除，避免继续输出孤立的旧插件 key。
+        self._previous_results = {
+            key: result
+            for key, result in self._previous_results.items()
+            if key in store_plugin_keys
+        }
+        # 插件配置与测试结果一样跟随插件列表收敛。
+        self._plugin_configs = {
+            key: config
+            for key, config in self._plugin_configs.items()
+            if key in store_plugin_keys
+        }
 
     def generate_github_summary(self, results: dict[str, StoreTestResult]):
         """生成 GitHub 摘要"""

--- a/tests/providers/store_test/test_store_sync.py
+++ b/tests/providers/store_test/test_store_sync.py
@@ -413,6 +413,120 @@ async def test_store_sync(
     )
 
 
+async def test_store_sync_removes_stale_registry_data(
+    mocked_store_data: dict[str, Path], mocked_api: MockRouter
+) -> None:
+    """同步商店数据时清理 nonebot2 仓库中已不存在的旧数据"""
+    from src.providers.constants import BOT_KEY_TEMPLATE, PYPI_KEY_TEMPLATE
+    from src.providers.store_test.store import StoreTest
+
+    test = StoreTest()
+
+    adapter_key = PYPI_KEY_TEMPLATE.format(
+        project_link="nonebot-adapter-onebot",
+        module_name="nonebot.adapters.onebot.v11",
+    )
+    stale_adapter_key = PYPI_KEY_TEMPLATE.format(
+        project_link="nonebot-adapter-onebot",
+        module_name="onebot.v11",
+    )
+    test._previous_adapters[stale_adapter_key] = test._previous_adapters[
+        adapter_key
+    ].model_copy(update={"module_name": "onebot.v11"})
+
+    bot_key = BOT_KEY_TEMPLATE.format(
+        name="CoolQBot",
+        homepage="https://github.com/he0119/CoolQBot",
+    )
+    stale_bot_key = BOT_KEY_TEMPLATE.format(
+        name="Old Bot",
+        homepage="https://example.com/old-bot",
+    )
+    test._previous_bots[stale_bot_key] = test._previous_bots[bot_key].model_copy(
+        update={"name": "Old Bot", "homepage": "https://example.com/old-bot"}
+    )
+
+    driver_key = PYPI_KEY_TEMPLATE.format(project_link="", module_name="~none")
+    stale_driver_key = PYPI_KEY_TEMPLATE.format(
+        project_link="nonebot2[old]",
+        module_name="~old",
+    )
+    test._previous_drivers[stale_driver_key] = test._previous_drivers[
+        driver_key
+    ].model_copy(update={"project_link": "nonebot2[old]", "module_name": "~old"})
+
+    plugin_key = PYPI_KEY_TEMPLATE.format(
+        project_link="nonebot-plugin-datastore",
+        module_name="nonebot_plugin_datastore",
+    )
+    stale_plugin_key = PYPI_KEY_TEMPLATE.format(
+        project_link="nonebot-plugin-old",
+        module_name="nonebot_plugin_old",
+    )
+    test._previous_plugins[stale_plugin_key] = test._previous_plugins[
+        plugin_key
+    ].model_copy(
+        update={
+            "module_name": "nonebot_plugin_old",
+            "project_link": "nonebot-plugin-old",
+        }
+    )
+    test._previous_results[stale_plugin_key] = test._previous_results[
+        plugin_key
+    ].model_copy(update={"version": "0.1.0"})
+    test._plugin_configs[stale_plugin_key] = "OLD_CONFIG=true"
+
+    await test.sync_store()
+    test.dump_data()
+
+    assert set(test._previous_adapters) == set(test._store_adapters)
+    assert set(test._previous_bots) == set(test._store_bots)
+    assert set(test._previous_drivers) == set(test._store_drivers)
+    assert stale_plugin_key not in test._previous_plugins
+    assert stale_plugin_key not in test._previous_results
+    assert stale_plugin_key not in test._plugin_configs
+
+    adapters = load_json(mocked_store_data["adapters"])
+    adapter_keys = {
+        PYPI_KEY_TEMPLATE.format(
+            project_link=adapter["project_link"],
+            module_name=adapter["module_name"],
+        )
+        for adapter in adapters
+    }
+    assert stale_adapter_key not in adapter_keys
+
+    bots = load_json(mocked_store_data["bots"])
+    bot_keys = {
+        BOT_KEY_TEMPLATE.format(name=bot["name"], homepage=bot["homepage"])
+        for bot in bots
+    }
+    assert stale_bot_key not in bot_keys
+
+    drivers = load_json(mocked_store_data["drivers"])
+    driver_keys = {
+        PYPI_KEY_TEMPLATE.format(
+            project_link=driver["project_link"],
+            module_name=driver["module_name"],
+        )
+        for driver in drivers
+    }
+    assert stale_driver_key not in driver_keys
+
+    plugins = load_json(mocked_store_data["plugins"])
+    plugin_keys = {
+        PYPI_KEY_TEMPLATE.format(
+            project_link=plugin["project_link"],
+            module_name=plugin["module_name"],
+        )
+        for plugin in plugins
+    }
+    assert stale_plugin_key not in plugin_keys
+
+    assert stale_plugin_key not in load_json(mocked_store_data["results"])
+    assert stale_plugin_key not in load_json(mocked_store_data["plugin_configs"])
+
+
 async def test_store_sync_validation_failed(
     mocked_store_data: dict[str, Path], mocked_api: MockRouter, mocker: MockerFixture
 ) -> None:


### PR DESCRIPTION
## 变更内容

- 将 `sync_store()` 调整为以 nonebot2 仓库 store 数据的 key 集合作为最终同步结果，避免 registry 中残留 store 已不存在的旧条目。
- 复用统一的 registry 同步辅助函数，覆盖适配器、机器人、驱动器和插件的增删改同步。
- 插件被移除时同步清理对应的 `registry results` 和 `plugin_configs` 孤立 key。
- 新增回归测试，覆盖 stale adapter/bot/driver/plugin 以及插件测试结果和配置残留。

## 根因

原先 `sync_store()` 只会更新已有条目和新增 store 中的新条目，但不会删除 registry 中已经存在、而 nonebot2 store 中已不存在的 key。若条目的 `module_name` 等组成 key 的字段发生变更，旧 key 会永久留在 registry 输出中。

## 验证

- `uv run pytest tests/providers/store_test`
- `uv run ruff format --check src/providers/store_test/store.py tests/providers/store_test/test_store_sync.py`
- `uv run ruff check src/providers/store_test/store.py tests/providers/store_test/test_store_sync.py`