### PR TITLE
fix(publish): 显示项目主页请求错误

### DIFF
--- a/src/plugins/github/plugins/publish/templates/render_error.md.jinja
+++ b/src/plugins/github/plugins/publish/templates/render_error.md.jinja
@@ -26,7 +26,7 @@
 {%- if ctx.status_code != -1 %}
 项目 <a href="{{ input }}">主页</a> 返回状态码 {{ ctx.status_code }}。<dt>请确保你的项目主页可访问。</dt>
 {%- else %}
-项目 <a href="{{ input }}">主页</a> 访问出错。{{ detail_message("错误信息", ctx.error) }}
+项目 <a href="{{ input }}">主页</a> 访问出错。{{ detail_message("错误信息", ctx.msg) }}
 {%- endif %}
 {%- elif type == "project_link.not_found" %}
 项目 <a href="https://pypi.org/project/{{ input }}/">{{ input }}</a> 未发布至 PyPI。<dt>请将你的项目发布至 PyPI。</dt>

--- a/src/providers/validation/utils.py
+++ b/src/providers/validation/utils.py
@@ -26,7 +26,7 @@ def check_url(url: str) -> tuple[int, str]:
         r = get_url(url)
         return r.status_code, ""
     except Exception as e:
-        logger.debug("访问网址 %s 时出错", url, exc_info=True)
+        logger.debug(f"访问网址 {url} 时出错", exc_info=True)
         return -1, str(e)
 
 

--- a/src/providers/validation/utils.py
+++ b/src/providers/validation/utils.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from src.providers.constants import STORE_ADAPTERS_URL
+from src.providers.logger import logger
 from src.providers.utils import get_url, load_json_from_web
 
 from .constants import MESSAGE_TRANSLATIONS
@@ -25,6 +26,7 @@ def check_url(url: str) -> tuple[int, str]:
         r = get_url(url)
         return r.status_code, ""
     except Exception as e:
+        logger.debug("访问网址 %s 时出错", url, exc_info=True)
         return -1, str(e)
 
 

--- a/tests/plugins/github/publish/render/test_publish_render_error.py
+++ b/tests/plugins/github/publish/render/test_publish_render_error.py
@@ -663,7 +663,7 @@ async def test_render_http_error(app: App, mocker: MockFixture):
 
 **⚠️ 在发布检查过程中，我们发现以下问题：**
 
-<pre><code><li>⚠️ 项目 <a href="https://www.baidu.com">主页</a> 返回状态码 404。<dt>请确保你的项目主页可访问。</dt></li><li>⚠️ 项目 <a href="12312">主页</a> 访问出错。<details><summary>错误信息</summary></details></li></code></pre>
+<pre><code><li>⚠️ 项目 <a href="https://www.baidu.com">主页</a> 返回状态码 404。<dt>请确保你的项目主页可访问。</dt></li><li>⚠️ 项目 <a href="12312">主页</a> 访问出错。<details><summary>错误信息</summary>Request URL is missing an &#39;http://&#39; or &#39;https://&#39; protocol.</details></li></code></pre>
 
 <details>
 <summary>详情</summary>


### PR DESCRIPTION
## Summary

- 修复主页请求异常详情使用错误上下文字段的问题
- 在 `check_url` 捕获请求异常时记录请求 URL 和完整 traceback
- 更新渲染回归测试，确保评论展示实际异常信息

Related: nonebot/nonebot2#4093

## Tests

- `pytest tests/plugins/github/publish/render/test_publish_render_error.py tests/providers/validation/fields/test_homepage.py -q`
- `uv run poe test`
- `ruff check`
- `ruff format --check`